### PR TITLE
SourceModel extensions and fixes

### DIFF
--- a/console/src/main/java/com/composum/sling/nodes/NodesConfiguration.java
+++ b/console/src/main/java/com/composum/sling/nodes/NodesConfiguration.java
@@ -38,6 +38,15 @@ public interface NodesConfiguration {
     @Nonnull
     ResourceFilter getSourceNodesFilter();
 
+    /** Determines for the SourceServlet whether the attributes are sorted by importance. */
+    boolean isSourceAdvancedSortAttributes();
+
+    /** Determines when a resource should be rendered as folder in the SourceServlet. */
+    ResourceFilter getSourceFolderNodesFilter();
+
+    /** Determines when a resource should be rendered as separate XML file ("vlt:FullCoverage") */
+    ResourceFilter getSourceXmlNodesFilter();
+
     @Nonnull
     String getScenesContentRoot();
 

--- a/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
+++ b/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
@@ -327,7 +327,7 @@ public class SourceModel extends ConsoleSlingBean {
             Iterator<Resource> iterator = resource.listChildren();
             while (iterator.hasNext()) {
                 Resource subnode = iterator.next();
-                if (config.getSourceNodesFilter().accept(subnode)) {
+                if (config.getSourceNodesFilter().accept(subnode) && !ResourceUtil.isSyntheticResource(subnode)) {
                     if (subnode.getName().equals(JCR_CONTENT)) {
                         jcrcontent = subnode;
                     } else {

--- a/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
+++ b/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
@@ -37,16 +37,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -140,17 +131,6 @@ public class SourceModel extends ConsoleSlingBean {
     public static final StringFilter EXCLUDED_MIXINS = new StringFilter.WhiteList("^rep:AccessControllable$");
 
     /**
-     * Filter matching nodes that are rendered as an XML file named like the node - "Full coverage aggregate" in
-     * Vault.
-     *
-     * @see "https://github.com/apache/jackrabbit-filevault/blob/trunk/vault-core/src/main/resources/org/apache/jackrabbit/vault/fs/config/defaultConfig-1.1.xml"
-     */
-    public static final ResourceFilter RENDERFILTER_XMLFILE =
-            new ResourceFilter.NodeTypeFilter(new StringFilter.WhiteList("^mix:language$", "^rep:AccessControl$",
-                    "^rep:Policy$", "^cq:Widget$", "^cq:EditConfig$", "^cq:WorkflowModel$", "^vlt:FullCoverage$",
-                    "^mix:language$", "^sling:OsgiConfig$"));
-
-    /**
      * Pattern for {@link SimpleDateFormat} that creates a date suitable with XML sources.
      */
     public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
@@ -176,6 +156,7 @@ public class SourceModel extends ConsoleSlingBean {
      * yet determined".
      */
     protected transient Boolean[] hasOrderableChildren;
+    protected transient Comparator<Property> propertyComparator;
 
     public SourceModel(NodesConfiguration config, BeanContext context, Resource resource) {
         if ("/".equals(ResourceUtil.normalize(resource.getPath()))) {
@@ -307,7 +288,7 @@ public class SourceModel extends ConsoleSlingBean {
                     propertyList.add(property);
                 }
             }
-            Collections.sort(propertyList);
+            Collections.sort(propertyList, getPropertyComparator());
         }
         return propertyList;
     }
@@ -927,12 +908,12 @@ public class SourceModel extends ConsoleSlingBean {
             // jcr:content shall always be the top node of a .content.xml
             return RenderingType.FOLDER;
         }
-        if (RENDERFILTER_XMLFILE.accept(aResource)) {
+        if (config.getSourceXmlNodesFilter().accept(aResource)) {
             // in theory it would be nice to have a rule here that everything below this stays in this file,
             // even if it's a folder, but that'd be inefficient or a hack - let's see later whether it'd be worth it.
             return RenderingType.XMLFILE;
         }
-        if (!inFullCoverageNode && ResourceUtil.isNodeType(aResource, ResourceUtil.NT_HIERARCHYNODE)) {
+        if (!inFullCoverageNode && config.getSourceFolderNodesFilter().accept(aResource)) {
             return RenderingType.FOLDER;
         }
         return RenderingType.EMBEDDED;
@@ -941,6 +922,18 @@ public class SourceModel extends ConsoleSlingBean {
     protected boolean isFullCoverageNode() {
         return resource.getName().equalsIgnoreCase(JCR_CONTENT) ||
                 RenderingType.XMLFILE == getRenderingType(resource, false);
+    }
+
+    protected Comparator<Property> getPropertyComparator() {
+        if (propertyComparator == null) {
+            propertyComparator =
+                    Comparator.nullsLast(Comparator.comparing(Property::getNs))
+                            .thenComparing(Property::getName);
+            if (this.config.isSourceAdvancedSortAttributes()) {
+                propertyComparator = Comparator.comparing(Property::getOrderingLevel).thenComparing(propertyComparator);
+            }
+        }
+        return propertyComparator;
     }
 
     /**
@@ -984,7 +977,7 @@ public class SourceModel extends ConsoleSlingBean {
         DEEP
     }
 
-    public static class Property implements Comparable<Property> {
+    public static class Property {
 
         protected final String name;
         protected final Object value;
@@ -1143,32 +1136,11 @@ public class SourceModel extends ConsoleSlingBean {
         }
 
         @Override
-        public int compareTo(@Nonnull Property other) {
-            int level = getOrderingLevel();
-            int olevel = other.getOrderingLevel();
-            if (level != olevel) {
-                return Integer.compare(level, olevel);
-            }
-            String ns = getNs();
-            String ons = other.getNs();
-            if (ns.isEmpty() && !ons.isEmpty()) {
-                return 1;
-            }
-            if (!ns.isEmpty() && ons.isEmpty()) {
-                return -1;
-            }
-            if (!ns.equals(ons)) {
-                return ns.compareTo(ons);
-            }
-            return getName().compareTo(other.getName());
-        }
-
-        @Override
         public boolean equals(Object o) {
-            if (!(o instanceof Property)) {
-                return false;
-            }
-            return compareTo((Property) o) == 0;
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Property property = (Property) o;
+            return Objects.equals(name, property.name) && Objects.equals(value, property.value) && Objects.equals(jcrType, property.jcrType);
         }
 
         @Override

--- a/console/src/main/java/com/composum/sling/nodes/update/SourceUpdateServiceImpl.java
+++ b/console/src/main/java/com/composum/sling/nodes/update/SourceUpdateServiceImpl.java
@@ -179,7 +179,7 @@ public class SourceUpdateServiceImpl implements SourceUpdateService {
             for (Resource child : resource.getChildren()) {
                 Resource templateChild = templateresource.getChild(child.getName());
                 if (templateChild == null) {
-                    if (!noRemoveNodeNames.contains(child.getName())) {
+                    if (!noRemoveNodeNames.contains(child.getName()) && !ResourceUtil.isSyntheticResource(child)) {
                         thisNodeChanged = true;
                         try {
                             resource.getResourceResolver().delete(child);

--- a/console/src/main/java/com/composum/sling/nodes/update/SourceUpdateServiceImpl.java
+++ b/console/src/main/java/com/composum/sling/nodes/update/SourceUpdateServiceImpl.java
@@ -3,13 +3,13 @@ package com.composum.sling.nodes.update;
 import com.composum.sling.core.ResourceHandle;
 import com.composum.sling.core.util.ResourceUtil;
 import org.apache.commons.collections.IteratorUtils;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.vault.fs.api.ProgressTrackerListener;
+import org.apache.jackrabbit.vault.fs.config.DefaultWorkspaceFilter;
 import org.apache.jackrabbit.vault.fs.io.Importer;
-import org.apache.jackrabbit.vault.fs.io.MemoryArchive;
+import org.apache.jackrabbit.vault.fs.io.ZipStreamArchive;
 import org.apache.sling.api.resource.*;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
@@ -24,6 +24,7 @@ import javax.jcr.nodetype.NodeDefinition;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.composum.sling.core.util.ResourceUtil.*;
 
@@ -39,7 +40,7 @@ public class SourceUpdateServiceImpl implements SourceUpdateService {
 
     /**
      * Attributes that are not modified on the target.
-     * See result of JCR query <code>/jcr:system/jcr:nodeTypes/*[jcr:isMixin=true]/rep:namedPropertyDefinitions//*[jcr:protected=true]</code>.
+     * See result of JCR query {@code /jcr:system/jcr:nodeTypes/*[jcr:isMixin=true]/rep:namedPropertyDefinitions//*[jcr:protected=true]}.
      */
     private static final Collection<String> ignoredMetadataAttributes = new HashSet<>(Arrays.asList("jcr:uuid", "jcr:lastModified",
             "jcr:lastModifiedBy", "jcr:created", "jcr:createdBy", "jcr:isCheckedOut", "jcr:baseVersion",
@@ -50,14 +51,14 @@ public class SourceUpdateServiceImpl implements SourceUpdateService {
 
     /**
      * Nodes that should not be removed from the target.
-     * See result of JCR query <code>/jcr:system/jcr:nodeTypes//element(*,nt:childNodeDefinition)[jcr:name]</code>
-     * and <code>/jcr:system/jcr:nodeTypes//rep:namedChildNodeDefinitions</code>
+     * See result of JCR query {@code /jcr:system/jcr:nodeTypes//element(*,nt:childNodeDefinition)[jcr:name]}
+     * and {@code /jcr:system/jcr:nodeTypes//rep:namedChildNodeDefinitions}
      */
     private static final Collection<String> noRemoveNodeNames = new HashSet<>(Arrays.asList("rep:policy", "oak:index", "rep:repoPolicy"));
 
     /**
      * Mixins that should not be removed from the target.
-     * See result of JCR query <code>/jcr:system/jcr:nodeTypes/*[jcr:isMixin=true]</code>
+     * See result of JCR query {@code /jcr:system/jcr:nodeTypes/*[jcr:isMixin=true]}
      */
     private static final Collection<String> noRemoveMixins = new HashSet<>(Arrays.asList(
             // various internal Jackrabbit stuff - we rather not touch that.
@@ -75,20 +76,20 @@ public class SourceUpdateServiceImpl implements SourceUpdateService {
     @Override
     public void updateFromZip(@Nonnull ResourceResolver resolver, @Nonnull InputStream rawZipInputStream, @Nonnull String nodePath)
             throws IOException, RepositoryException {
-        Session session = resolver.adaptTo(Session.class);
+        Session session = Objects.requireNonNull(resolver.adaptTo(Session.class));
         Resource tmpdir = makeTempdir(resolver);
         final String tmpPath = tmpdir.getPath();
 
         Importer importer;
         ImportErrorListener errorListener = new ImportErrorListener();
+        ZipStreamArchive archive = new ZipStreamArchive(rawZipInputStream);
         try {
             importer = new Importer();
-            // TODO(hps,11.02.20) Use ZipStreamArchive once that's public (in later vault versions)
-            MemoryArchive archive = new MemoryArchive(false);
-            archive.run(rawZipInputStream);
-            importer.getOptions().setStrict(true);
+            importer.getOptions().setFilter(new DefaultWorkspaceFilter());
             importer.getOptions().setListener(errorListener);
-            importer.run(archive, tmpdir.adaptTo(Node.class));
+            archive.open(true);
+            LOG.info("Importing {}", archive.getMetaInf().getProperties());
+            importer.run(archive, session, tmpdir.getPath());
         } catch (IOException | RepositoryException e) {
             throw e;
         } catch (Exception e) {
@@ -99,7 +100,7 @@ public class SourceUpdateServiceImpl implements SourceUpdateService {
         if (importer.hasErrors()) {
             StringBuilder buf = new StringBuilder("Errors during import: ");
             errorListener.errors.forEach(e ->
-                    buf.append(e.getLeft()).append(" : ").append(String.valueOf(e.getRight())).append("\n"));
+                    buf.append(e.getLeft()).append(" : ").append(e.getRight()).append("\n"));
             throw new RepositoryException(buf.toString());
         }
 
@@ -143,27 +144,12 @@ public class SourceUpdateServiceImpl implements SourceUpdateService {
         }
 
         try {
-            // first copy type information since this changes attributes
-            newvalues.put(PROP_PRIMARY_TYPE, templatevalues.get(PROP_PRIMARY_TYPE));
-            List<String> newMixins = new ArrayList<>(Arrays.asList(templatevalues.get(PROP_MIXINTYPES, new String[0])));
-            for (String mixin : newvalues.get(PROP_MIXINTYPES, new String[0])) {
-                if (noRemoveMixins.contains(mixin) && !newMixins.contains(mixin)) {
-                    newMixins.add(mixin);
-                }
-            }
-            if (!newMixins.isEmpty() || newvalues.containsKey(PROP_MIXINTYPES)) {
-                newvalues.put(PROP_MIXINTYPES, newMixins.toArray(new String[newMixins.size()]));
-            }
-
-            Node node = resource.adaptTo(Node.class);
-            NodeDefinition definition = node.getDefinition();
-            if (definition.allowsSameNameSiblings()) {
-                checkForSamenameSiblings(templateresource, resource);
-            }
+            copyTypeInformation(templatevalues, newvalues); // first this since it might change attributes.
+            checkForSamenameSiblings(templateresource, resource);
 
             for (Map.Entry<String, Object> entry : templatevalues.entrySet()) {
                 if (!ignoredMetadataAttributes.contains(entry.getKey()) &&
-                        ObjectUtils.notEqual(entry.getValue(), newvalues.get(entry.getKey()))) {
+                        !Objects.deepEquals(entry.getValue(), newvalues.get(entry.getKey()))) {
                     thisNodeChanged = true;
                     newvalues.put(entry.getKey(), entry.getValue());
                 }
@@ -203,9 +189,7 @@ public class SourceUpdateServiceImpl implements SourceUpdateService {
                 }
             }
 
-            if (node.getPrimaryNodeType().hasOrderableChildNodes()) {
-                ensureSameOrdering(templatechildren, resource);
-            }
+            ensureSameOrdering(templatechildren, resource);
 
             if (thisNodeChanged) {
                 Resource modifcandidate = resource;
@@ -222,42 +206,63 @@ public class SourceUpdateServiceImpl implements SourceUpdateService {
         }
     }
 
+    private void copyTypeInformation(ValueMap templatevalues, ModifiableValueMap newvalues) {
+        newvalues.put(PROP_PRIMARY_TYPE, templatevalues.get(PROP_PRIMARY_TYPE));
+        List<String> newMixins = new ArrayList<>(Arrays.asList(templatevalues.get(PROP_MIXINTYPES, new String[0])));
+        for (String mixin : newvalues.get(PROP_MIXINTYPES, new String[0])) {
+            if (noRemoveMixins.contains(mixin) && !newMixins.contains(mixin)) {
+                newMixins.add(mixin);
+            }
+        }
+        if (!newMixins.isEmpty() || newvalues.containsKey(PROP_MIXINTYPES)) {
+            newvalues.put(PROP_MIXINTYPES, newMixins.toArray(new String[0]));
+        }
+    }
+
     private void ensureSameOrdering(List<Resource> templatechildren, Resource resource) throws RepositoryException {
-        Node node = Objects.requireNonNull(resource.adaptTo(Node.class));
-        List<Resource> resourcechildren = IteratorUtils.toList(resource.listChildren());
-        if (templatechildren.size() != resourcechildren.size()) {
-            throw new IllegalStateException("Bug: template and resource of " + resource.getPath() +
-                    " should have same size now but have " + templatechildren.size() + " and " + resourcechildren.size());
-        }
-        if (resourcechildren.size() < 2) {
-            return;
-        }
-        Map<String, Resource> nameToNode = new HashMap<>();
-        for (Resource child : resourcechildren) {
-            nameToNode.put(child.getName(), child);
-        }
-        for (int i = 0; i < resourcechildren.size(); ++i) {
-            if (!StringUtils.equals(resourcechildren.get(i).getName(), templatechildren.get(i).getName())) {
-                node.orderBefore(templatechildren.get(i).getName(), resourcechildren.get(i).getName());
-                resourcechildren = IteratorUtils.toList(resource.listChildren());
+        if (resource.adaptTo(Node.class).getPrimaryNodeType().hasOrderableChildNodes()) {
+            templatechildren = filterNoRemoveNodes(templatechildren);
+            Node node = Objects.requireNonNull(resource.adaptTo(Node.class));
+            List<Resource> resourcechildren = filterNoRemoveNodes(IteratorUtils.toList(resource.listChildren()));
+            if (templatechildren.size() != resourcechildren.size()) {
+                throw new IllegalStateException("Bug: template and resource of " + resource.getPath() +
+                        " should have same size now but have " + templatechildren.size() + " and " + resourcechildren.size());
+            }
+            if (resourcechildren.size() < 2) {
+                return;
+            }
+            for (int i = 0; i < resourcechildren.size(); ++i) {
+                if (!StringUtils.equals(resourcechildren.get(i).getName(), templatechildren.get(i).getName())) {
+                    node.orderBefore(templatechildren.get(i).getName(), resourcechildren.get(i).getName());
+                    resourcechildren = filterNoRemoveNodes(IteratorUtils.toList(resource.listChildren()));
+                }
             }
         }
     }
 
-    private void checkForSamenameSiblings(Resource templateresource, @Nonnull Resource resource) throws IllegalArgumentException {
-        Set<String> nodenames = new HashSet<>();
-        for (Resource child : templateresource.getChildren()) {
-            if (nodenames.contains(child.getName())) {
-                throw new IllegalArgumentException("Equally named children not supported yet: existing resource " + templateresource.getPath() + " has two " + child.getName());
+    private List<Resource> filterNoRemoveNodes(List<Resource> children) {
+        return children.stream().filter(r -> !noRemoveNodeNames.contains(r.getName())).collect(Collectors.toList());
+    }
+
+    private void checkForSamenameSiblings(Resource templateresource, @Nonnull Resource resource)
+            throws IllegalArgumentException, RepositoryException {
+        Node node = resource.adaptTo(Node.class);
+        NodeDefinition definition = node.getDefinition();
+        if (definition.allowsSameNameSiblings()) {
+            Set<String> nodenames = new HashSet<>();
+            for (Resource child : templateresource.getChildren()) {
+                if (nodenames.contains(child.getName())) {
+                    throw new IllegalArgumentException("Equally named children not supported yet: existing resource " + templateresource.getPath() + " has two " + child.getName());
+                }
+                nodenames.add(child.getName());
             }
-            nodenames.add(child.getName());
-        }
-        nodenames.clear();
-        for (Resource child : resource.getChildren()) {
-            if (nodenames.contains(child.getName())) {
-                throw new IllegalArgumentException("Equally named children not supported yet: imported resource " + resource.getPath() + " has two " + child.getName());
+            nodenames.clear();
+            for (Resource child : resource.getChildren()) {
+                if (nodenames.contains(child.getName())) {
+                    throw new IllegalArgumentException("Equally named children not supported yet: imported resource " + resource.getPath() + " has two " + child.getName());
+                }
+                nodenames.add(child.getName());
             }
-            nodenames.add(child.getName());
         }
     }
 
@@ -267,12 +272,13 @@ public class SourceUpdateServiceImpl implements SourceUpdateService {
 
         @Override
         public void onMessage(Mode mode, String action, String path) {
-            // ignore
+            LOG.debug("Import message {} : {} : {}", mode, action, path);
         }
 
         @Override
         public void onError(Mode mode, String path, Exception e) {
             errors.add(Pair.of(path, e));
+            LOG.debug("Import error {} : {} : {}", mode, path, String.valueOf(e));
         }
     }
 }

--- a/console/src/main/resources/root/libs/composum/nodes/browser/components/overlay/remove/remove.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/components/overlay/remove/remove.jsp
@@ -22,7 +22,7 @@
                     </div>
                     <div class="form-group">
                         <cpn:text class="text" i18n="true"
-                                  type="rich">Do you really want to delete the current overlay; this cannot be undone?</cpn:text>
+                                  type="rich">Do you really want to delete the current overlay? This cannot be undone.</cpn:text>
                     </div>
                     <div class="form-group">
                         <label class="control-label">${cpn:i18n(slingRequest,'Overlay Path')}</label>

--- a/console/src/main/resources/root/libs/composum/nodes/browser/i18n/de.json
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/i18n/de.json
@@ -37,7 +37,7 @@
     },
     "remove-overlay-text": {
       "jcr:primaryType": "sling:MessageEntry",
-      "sling:key": "Do you really want to delete the current overlay; this cannot be undone?",
+      "sling:key": "Do you really want to delete the current overlay? This cannot be undone.",
       "sling:message": "Wollen Sie das aktuelle Overlay wirklich löschen; dies kann nicht rückgängig gemacht werden?"
     }
   }

--- a/console/src/main/resources/root/libs/composum/nodes/browser/query/templates.json
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/query/templates.json
@@ -24,11 +24,11 @@
   "by-node-type": {
     "jcr:primaryType": "nt:unstructured",
     "sling:resourceType": "composum/nodes/browser/query/template",
-    "jcr:title": "search by primary or mixin type",
+    "jcr:title": "search by node type",
     "group": "Nodes",
     "order": 120,
     "jcr:description": "\u003cp\u003eis searching all nodes with matching node type\u003c/p\u003e",
-    "xpath": "/jcr:root${root_path.path}//*[@jcr:primaryType\u003d\u0027${type}\u0027 or @jcr:mixinTypes\u003d\u0027${type}\u0027]"
+    "xpath": "/jcr:root${root_path.path}//element(*,${type})"
   },
   "by-uuid": {
     "jcr:primaryType": "nt:unstructured",

--- a/test/src/test/resources/jcr_root/content/composum/nodes/console/test/sourcemodel/subfolder/.content.xml
+++ b/test/src/test/resources/jcr_root/content/composum/nodes/console/test/sourcemodel/subfolder/.content.xml
@@ -9,9 +9,9 @@
             jcr:title="various cases">
         <folder
                 jcr:primaryType="sling:Folder"
-                jcr:description="Should not have a folder"
                 _x0026__x003c__x003e__x0027__x005c_="attribute name crap &amp;&lt;>'"
-                äöüÄ_x005c__x0022__x0027_ÖÜñóáéíóú_x00ac_áßàèìùòâêîôû_x0020__x0026__x003c__x0026__x003e_xml_x003b__x0020__x0026_euro_x003b__x0020__x0040__x0025__x2030__x0020__x00bc__x00bd__x00be__x0020__x00ab__x2122__x00a9__x00ae__x00bb__x0020__x201e__x0024__x201d__x201c__x20ac__x201d__x2018__x00a3__x2019__x201a__x00a5__x2019__x0020__x003c_b_x003e__x0021__x003c_b_x003e_="unspeakable horrors"/>
+                äöüÄ_x005c__x0022__x0027_ÖÜñóáéíóú_x00ac_áßàèìùòâêîôû_x0020__x0026__x003c__x0026__x003e_xml_x003b__x0020__x0026_euro_x003b__x0020__x0040__x0025__x2030__x0020__x00bc__x00bd__x00be__x0020__x00ab__x2122__x00a9__x00ae__x00bb__x0020__x201e__x0024__x201d__x201c__x20ac__x201d__x2018__x00a3__x2019__x201a__x00a5__x2019__x0020__x003c_b_x003e__x0021__x003c_b_x003e_="unspeakable horrors"
+                jcr:description="Should not have a folder"/>
         <assets
                 jcr:primaryType="nt:unstructured">
             <withadditionaldata.jpg/>

--- a/tools/bin/downloadJcrDirectory.sh
+++ b/tools/bin/downloadJcrDirectory.sh
@@ -76,8 +76,8 @@ echo EXTRACTION:
 echo
 if command -v 7z &> /dev/null
 then
-  7z x $CPM_CPM_7Z_EXTRACT_EXCLUDE -y $TMPFIL
-  if [ -n $CPM_CPM_7Z_EXTRACT_EXCLUDE ]; then
+  7z x "$CPM_CPM_7Z_EXTRACT_EXCLUDE" -y $TMPFIL
+  if [ -n "$CPM_CPM_7Z_EXTRACT_EXCLUDE" ]; then
     echo Using 7z additional switches $CPM_7Z_EXTRACT_EXCLUDE
   fi
 else


### PR DESCRIPTION
This extends the configuration of the Composum Browser source mechanisms to be more compatible with various methods to structure the source for the JCR resources in AEM projects.

It extends the browser mechanism to show XML source for nodes and export zip / packages of the sources such that it is now which nodes are exported a a folder (with a .content.xml) and which are exported as separate XML files (e.g. internationalizations en.xml, de.xml, ...). Also it is now possible to use the plain lexical sorting of attributes for source exports instead of showing jcr:primaryType, jcr:mixins and sling:* attributes first - see the "Composum Nodes (Console) Configuration" in the OSGI configurations.

Included is also a performance improvement and fix for the SourceUpdateService, which can be used to quickly synchronize the JCR content with source files in the IDE.