### PR TITLE
Misc. Browser improvements

### DIFF
--- a/commons/src/main/java/com/composum/sling/clientlibs/handle/FileHandle.java
+++ b/commons/src/main/java/com/composum/sling/clientlibs/handle/FileHandle.java
@@ -8,6 +8,7 @@ import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,8 +45,8 @@ public class FileHandle {
     protected transient String encoding;
     protected transient Calendar lastModified;
 
-    public FileHandle(Resource resource) {
-        if (JcrConstants.JCR_CONTENT.equals(resource.getName())) {
+    public FileHandle(@Nullable Resource resource) {
+        if (resource != null && JcrConstants.JCR_CONTENT.equals(resource.getName())) {
             Resource parent = resource.getParent();
             if (parent != null && ResourceUtil.isFile(parent)) {
                 resource = parent;

--- a/commons/src/main/java/com/composum/sling/clientlibs/handle/FileHandle.java
+++ b/commons/src/main/java/com/composum/sling/clientlibs/handle/FileHandle.java
@@ -3,6 +3,7 @@ package com.composum.sling.clientlibs.handle;
 import com.composum.sling.core.ResourceHandle;
 import com.composum.sling.core.util.ResourceUtil;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -44,16 +45,26 @@ public class FileHandle {
     protected transient Calendar lastModified;
 
     public FileHandle(Resource resource) {
+        if (JcrConstants.JCR_CONTENT.equals(resource.getName())) {
+            Resource parent = resource.getParent();
+            if (parent != null && ResourceUtil.isFile(parent)) {
+                resource = parent;
+            }
+        }
         this.resource = ResourceHandle.use(resource);
         this.content = retrieveContent();
     }
 
-    /** Handle to the content node of the file; not null. */
+    /**
+     * Handle to the content node of the file; not null.
+     */
     public ResourceHandle getContent() {
         return content;
     }
 
-    /** Handle to the main node of the file; not null. */
+    /**
+     * Handle to the main node of the file; not null.
+     */
     public ResourceHandle getResource() {
         return resource;
     }
@@ -139,7 +150,9 @@ public class FileHandle {
         }
     }
 
-    /** Updates the last modified value, if the mix:lastModified is present. */
+    /**
+     * Updates the last modified value, if the mix:lastModified is present.
+     */
     public void updateLastModified() {
         if (content.isValid()) {
             ModifiableValueMap values = Objects.requireNonNull(content.adaptTo(ModifiableValueMap.class));

--- a/commons/src/main/java/com/composum/sling/clientlibs/handle/ImageHandle.java
+++ b/commons/src/main/java/com/composum/sling/clientlibs/handle/ImageHandle.java
@@ -2,9 +2,11 @@ package com.composum.sling.clientlibs.handle;
 
 import org.apache.sling.api.resource.Resource;
 
+import javax.annotation.Nullable;
+
 public class ImageHandle extends FileHandle {
 
-    public ImageHandle(Resource resource) {
+    public ImageHandle(@Nullable Resource resource) {
         super(resource);
     }
 }

--- a/commons/src/main/resources/root/libs/composum/nodes/commons.json
+++ b/commons/src/main/resources/root/libs/composum/nodes/commons.json
@@ -1,3 +1,0 @@
-{
-  "jcr:primaryType": "sling:Folder"
-}

--- a/commons/src/main/resources/root/libs/composum/nodes/commons/components/js/tree.js
+++ b/commons/src/main/resources/root/libs/composum/nodes/commons/components/js/tree.js
@@ -505,26 +505,27 @@
                 }
             },
 
-            onPathDeleted: function (event, path) {
+            /** Event handler for path:deleted: newPath optionally determines which path should be displayed afterwards. */
+            onPathDeleted: function (event, path, newPath) {
                 var deleted = this.getTreeNodeByPath(path);
                 if (this.log.getLevel() <= log.levels.DEBUG) {
                     this.log.debug(this.nodeIdPrefix + 'tree.onPathDeleted(' + path + '):' + deleted);
                 }
                 if (deleted) {
                     var selected = this.getSelectedTreeNode();
-                    var nearestFocus = this.findNearestOfDeletion(path);
-                    var nearestSelection = undefined;
+                    var nextFocus = this.getTreeNode(newPath) || this.findNearestOfDeletion(path);
+                    var nextSelection = undefined;
                     if (selected && selected.original.path === path) {
-                        nearestSelection = this.findNearestOfDeletion(path);
+                        nextSelection = this.getTreeNode(newPath) || this.findNearestOfDeletion(path);
                     }
                     this.refreshNodeById(this.getParentNodeId(deleted.id), _.bind(function () {
                         var path;
-                        if (nearestSelection) {
-                            path = nearestSelection.original.path;
+                        if (nextSelection) {
+                            path = nextSelection.original.path;
                             this.selectNode(path);
                         }
-                        if (nearestFocus) {
-                            path = nearestFocus.original.path;
+                        if (nextFocus) {
+                            path = nextFocus.original.path;
                             var $anchor = this.get$TreeNodeAnchor(path);
                             $anchor.focus();
                         }

--- a/console/src/main/java/com/composum/sling/nodes/browser/Browser.java
+++ b/console/src/main/java/com/composum/sling/nodes/browser/Browser.java
@@ -351,18 +351,23 @@ public class Browser extends ConsoleServletBean {
         return typeSearchPath;
     }
 
+    /**
+     * The chain of resource super types. This is also included for content resources since this is used quite often in AEM.
+     * @see "https://experienceleague.adobe.com/docs/experience-manager-65/developing/introduction/the-basics.html?lang=en#sling-request-processing"
+     */
     @Nonnull
     public List<String> getSupertypeChain() {
         if (supertypeChain == null) {
             supertypeChain = new ArrayList<>();
-            if (isDeclaringType()) {
-                Resource typeResource = getTypeResource(getPath(), isOverlayResource());
-                while (typeResource != null) {
-                    ValueMap values = typeResource.getValueMap();
-                    typeResource = getTypeResource(values.get(PROP_RESOURCE_SUPER_TYPE, ""), isOverlayResource());
-                    if (typeResource != null) {
-                        supertypeChain.add(typeResource.getPath());
-                    }
+            Resource typeResource = resource;
+            if (isDeclaringType()) { // start from "highest" resource wrt. search path
+                typeResource = getTypeResource(getResourceType(getPath()), false);
+            }
+            while (typeResource != null) {
+                ValueMap values = typeResource.getValueMap();
+                typeResource = getTypeResource(values.get(PROP_RESOURCE_SUPER_TYPE, ""), false);
+                if (typeResource != null) {
+                    supertypeChain.add(typeResource.getPath());
                 }
             }
         }

--- a/console/src/main/java/com/composum/sling/nodes/browser/Browser.java
+++ b/console/src/main/java/com/composum/sling/nodes/browser/Browser.java
@@ -38,8 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import static com.composum.sling.core.util.CoreConstants.DEFAULT_OVERLAY_ROOT;
-import static com.composum.sling.core.util.CoreConstants.DEFAULT_OVERRIDE_ROOT;
 import static com.composum.sling.core.util.CoreConstants.PROP_RESOURCE_SUPER_TYPE;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -118,6 +116,8 @@ public class Browser extends ConsoleServletBean {
         FILE_ICONS.put("ppt", "powerpoint");
         FILE_ICONS.put("pptx", "powerpoint");
     }
+
+    private transient MergeMountpointService mergeMountpointService;
 
     public static class Reference {
 
@@ -458,8 +458,14 @@ public class Browser extends ConsoleServletBean {
     }
 
     public String getOverlayRoot() {
-        // TODO: ask the merger service
-        return DEFAULT_OVERLAY_ROOT;
+        return getMergeMountpointService().overlayMergeMountPoint(getResolver());
+    }
+
+    private MergeMountpointService getMergeMountpointService() {
+        if (mergeMountpointService == null) {
+            mergeMountpointService = this.getSling().getService(MergeMountpointService.class);
+        }
+        return mergeMountpointService;
     }
 
     public boolean isOverlayResource() {
@@ -483,8 +489,7 @@ public class Browser extends ConsoleServletBean {
     }
 
     public String getOverrideRoot() {
-        // TODO: ask the merger service
-        return DEFAULT_OVERRIDE_ROOT;
+        return getMergeMountpointService().overrideMergeMountPoint(getResolver());
     }
 
     public boolean isOverrideResource() {

--- a/console/src/main/java/com/composum/sling/nodes/browser/MergeMountpointService.java
+++ b/console/src/main/java/com/composum/sling/nodes/browser/MergeMountpointService.java
@@ -1,0 +1,16 @@
+package com.composum.sling.nodes.browser;
+
+import org.apache.sling.api.resource.ResourceResolver;
+
+public interface MergeMountpointService {
+
+    /**
+     * The position of the Sling resource type hierarchy based resource merger , normally /mnt/override .
+     */
+    String overrideMergeMountPoint(ResourceResolver resolver);
+
+    /**
+     * The position of the Sling search based resource picker, normally /mnt/overlay .
+     */
+    String overlayMergeMountPoint(ResourceResolver resolver);
+}

--- a/console/src/main/java/com/composum/sling/nodes/browser/impl/MergeMountpointServiceImpl.java
+++ b/console/src/main/java/com/composum/sling/nodes/browser/impl/MergeMountpointServiceImpl.java
@@ -1,0 +1,90 @@
+package com.composum.sling.nodes.browser.impl;
+
+import com.composum.sling.nodes.browser.MergeMountpointService;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.spi.resource.provider.ResourceProvider;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.composum.sling.core.util.CoreConstants.DEFAULT_OVERLAY_ROOT;
+import static com.composum.sling.core.util.CoreConstants.DEFAULT_OVERRIDE_ROOT;
+
+@Component(service = MergeMountpointService.class)
+public class MergeMountpointServiceImpl implements MergeMountpointService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MergeMountpointServiceImpl.class);
+
+    private BundleContext bundleContext;
+
+    private volatile String overrideMountPoint;
+    private volatile String overlayMountPoint;
+
+    @Activate
+    @Modified
+    protected void activate(final BundleContext bundleContext) throws InvalidSyntaxException {
+        this.bundleContext = bundleContext;
+        overlayMountPoint = null;
+        overrideMountPoint = null;
+        for (ServiceReference<ResourceProvider> sr : bundleContext.getServiceReferences(ResourceProvider.class, "(provider.name=Merging)")) {
+            String root = (String) sr.getProperty(ResourceProvider.PROPERTY_ROOT);
+            // Unfortunately it doesn't seem possible to distinguish those other than guessing :-(
+            if (StringUtils.contains(root, "overlay")) {
+                overlayMountPoint = root;
+            } else if (StringUtils.contains(root, "override")) {
+                overrideMountPoint = root;
+            }
+        }
+    }
+
+    private void init(ResourceResolver resolver) {
+        if (overlayMountPoint != null) {
+            return;
+        }
+        try {
+            List<String> mountpoints = bundleContext.getServiceReferences(ResourceProvider.class, "(provider.name=Merging)").stream()
+                    .map(sr -> (String) sr.getProperty(ResourceProvider.PROPERTY_ROOT)).collect(Collectors.toList());
+            // Unfortunately I don't see an easy way to determine which one is which one from the service reference nor from the provider.
+            // so we try to distinguish them from their content: the override contains subresources according to the search path,
+            // but overlay doesn't.
+            overrideMountPoint = mountpoints.stream()
+                    .filter(m -> isOverrideMountpoint(m, resolver))
+                    .findFirst().orElse(DEFAULT_OVERRIDE_ROOT);
+            mountpoints.remove(overrideMountPoint);
+            overlayMountPoint = mountpoints.isEmpty() ? DEFAULT_OVERLAY_ROOT : mountpoints.get(0);
+        } catch (InvalidSyntaxException e) { // bug.
+            LOG.error("" + e, e);
+        }
+    }
+
+    private boolean isOverrideMountpoint(String mountpoint, ResourceResolver resolver) {
+        boolean hasMissingEntry = Arrays.asList(resolver.getSearchPath()).stream()
+                .map(p -> resolver.getResource(mountpoint + p))
+                .filter(Objects::isNull)
+                .findAny().isPresent();
+        return !hasMissingEntry;
+    }
+
+    @Override
+    public String overrideMergeMountPoint(ResourceResolver resolver) {
+        init(resolver);
+        return StringUtils.defaultString(overrideMountPoint, DEFAULT_OVERRIDE_ROOT);
+    }
+
+    @Override
+    public String overlayMergeMountPoint(ResourceResolver resolver) {
+        init(resolver);
+        return StringUtils.defaultString(overlayMountPoint, DEFAULT_OVERLAY_ROOT);
+    }
+}

--- a/console/src/main/java/com/composum/sling/nodes/components/codeeditor/CodeEditor.java
+++ b/console/src/main/java/com/composum/sling/nodes/components/codeeditor/CodeEditor.java
@@ -12,6 +12,8 @@ import org.apache.tika.mime.MimeType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.composum.sling.nodes.browser.Browser.EDITOR_MODES;
+
 public class CodeEditor extends ConsoleServletBean {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConsolePage.class);
@@ -39,7 +41,7 @@ public class CodeEditor extends ConsoleServletBean {
         if (textType == null) {
             MimeType mimeType = MimeTypeUtil.getMimeType(resource);
             String extension = ResourceUtil.getNameExtension(resource);
-            textType = Browser.getTextType(mimeType != null ? mimeType.toString() : "", extension);
+            textType = Browser.getFileType(EDITOR_MODES, mimeType != null ? mimeType.toString() : "", extension);
         }
         return textType;
     }

--- a/console/src/main/java/com/composum/sling/nodes/servlet/ComponentsServlet.java
+++ b/console/src/main/java/com/composum/sling/nodes/servlet/ComponentsServlet.java
@@ -19,6 +19,8 @@ import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -35,6 +37,8 @@ import java.io.IOException;
         }
 )
 public class ComponentsServlet extends AbstractServiceServlet {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ComponentsServlet.class);
 
     public static final String SERVLET_PATH = "/bin/cpm/nodes/components";
 
@@ -107,7 +111,7 @@ public class ComponentsServlet extends AbstractServiceServlet {
                          @Nonnull final SlingHttpServletResponse response,
                          @Nullable final ResourceHandle resource)
                 throws IOException {
-            final Status status = new Status(request, response);
+            final Status status = new Status(request, response, LOG);
             final String type = getComponentType(request, resource);
             if (StringUtils.isNotBlank(type)) {
                 ResourceResolver resolver = request.getResourceResolver();
@@ -131,7 +135,7 @@ public class ComponentsServlet extends AbstractServiceServlet {
                          @Nonnull final SlingHttpServletResponse response,
                          @Nullable final ResourceHandle resource)
                 throws IOException {
-            final Status status = new Status(request, response);
+            final Status status = new Status(request, response, LOG);
             final String type = getComponentType(request, resource);
             if (StringUtils.isNotBlank(type)) {
                 ResourceResolver resolver = request.getResourceResolver();

--- a/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
+++ b/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
@@ -159,9 +159,6 @@ public class SourceModel extends ConsoleSlingBean {
     protected transient Comparator<Property> propertyComparator;
 
     public SourceModel(NodesConfiguration config, BeanContext context, Resource resource) {
-        if ("/".equals(ResourceUtil.normalize(resource.getPath()))) {
-            throw new IllegalArgumentException("Cannot export the whole JCR - " + resource.getPath());
-        }
         this.config = config;
         initialize(context, resource);
     }

--- a/console/src/main/resources/root/libs/composum/nodes/browser/components/overlay/create/create.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/components/overlay/create/create.jsp
@@ -22,7 +22,7 @@
                     </div>
                     <div class="form-group">
                         <cpn:text class="text" i18n="true"
-                                  type="rich">Do you want to create an overlay to the current component or copy from this template again?</cpn:text>
+                                  type="rich">Do you want to create an overlay to the current component?</cpn:text>
                     </div>
                     <div class="form-group">
                         <label class="control-label">${cpn:i18n(slingRequest,'Overlay Path')}</label>

--- a/console/src/main/resources/root/libs/composum/nodes/browser/css/browser.css
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/css/browser.css
@@ -970,14 +970,14 @@
  */
 
 #browser-view .node-view-panel .node-view-content .video .detail-content {
-    top: 37px;
-    bottom: 40px;
+    top: 34px;
     background-color: #666;
 }
 
 #browser-view .video.detail-panel .detail-content .video-frame {
     display: table;
     margin: auto;
+    padding: 6px;
 }
 
 #browser-view .video.detail-panel .detail-content .video-frame .video-background {
@@ -986,6 +986,16 @@
 
 #browser-view .video.detail-panel .detail-content .video-frame video {
     width: 100%;
+}
+
+#browser-view .binary.detail-panel .detail-content .file-download {
+    position: absolute;
+    top: 45%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 150px;
+    opacity: 0.4;
+    color: inherit;
 }
 
 /*

--- a/console/src/main/resources/root/libs/composum/nodes/browser/i18n/de.json
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/i18n/de.json
@@ -27,8 +27,8 @@
     },
     "create-overlay-text": {
       "jcr:primaryType": "sling:MessageEntry",
-      "sling:key": "Do you want to create an overlay to the current component or copy from this template again?",
-      "sling:message": "Wollen sie ein Overlay zur aktuellen Komponente anlegen bzw. erneut von dieser Vorlage kopieren?"
+      "sling:key": "Do you want to create an overlay to the current component?",
+      "sling:message": "Wollen sie ein Overlay zur aktuellen Komponente anlegen?"
     },
     "remove-overlay-title": {
       "jcr:primaryType": "sling:MessageEntry",

--- a/console/src/main/resources/root/libs/composum/nodes/browser/js/browser.js
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/js/browser.js
@@ -25,13 +25,13 @@
             return browser.current ? browser.current.path : undefined;
         };
 
-        browser.setCurrentPath = function (path, supressEvent) {
+        browser.setCurrentPath = function (path, supressEvent, suppressPush) {
             if (!browser.current || browser.current.path !== path) {
                 if (path) {
                     browser.refreshCurrentPath(path, _.bind(function (result) {
                         core.console.getProfile().set('browser', 'current', path);
-                        if (history.replaceState) {
-                            history.replaceState(browser.current.path, name, browser.current.nodeUrl);
+                        if (history.pushState && !suppressPush) {
+                            history.pushState(browser.current.path, name, browser.current.nodeUrl);
                         }
                         if (!supressEvent) {
                             $(document).trigger("path:selected", [path]);
@@ -45,6 +45,14 @@
                 }
             }
         };
+
+        browser.onPopState = function(event) {
+            if (event.state) {
+                browser.setCurrentPath(event.state, false, true);
+            }
+        }
+
+        window.onpopstate = browser.onPopState;
 
         browser.refreshCurrentPath = function (path, callback) {
             if (!path && browser.current) {

--- a/console/src/main/resources/root/libs/composum/nodes/browser/js/browser.js
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/js/browser.js
@@ -240,7 +240,7 @@
                         var newNodeName = core.getNameFromPath(path);
                         var parentPath = core.getParentPath(path);
                         $(document).trigger("path:inserted", [parentPath, newNodeName]);
-                        $(document).trigger("path:select", [path]);
+                        browser.setCurrentPath(path);
                     }, this));
             },
 
@@ -249,7 +249,15 @@
                 core.openFormDialog(u.base + u._remove + path,
                     core.components.FormDialog, {}, undefined,
                     _.bind(function () {
-                        $(document).trigger('path:deleted', [path]);
+                        var overlayPaths = this.$relatedPaths.filter('.is-overlay').map( (e,i) => i.dataset.path);
+                        var candidatePaths = overlayPaths.filter( (e,i) => e !== path);
+                        if (candidatePaths.length > 0) { // select another overlay of the component
+                            var newPath = candidatePaths[0];
+                            $(document).trigger('path:deleted', [path, newPath]);
+                            browser.setCurrentPath(path);
+                        } else {
+                            $(document).trigger('path:deleted', [path]);
+                        }
                     }, this));
             },
 

--- a/console/src/main/resources/root/libs/composum/nodes/browser/js/browser.js
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/js/browser.js
@@ -250,7 +250,7 @@
                     core.components.FormDialog, {}, undefined,
                     _.bind(function () {
                         var overlayPaths = this.$relatedPaths.filter('.is-overlay').map( (e,i) => i.dataset.path);
-                        var candidatePaths = overlayPaths.filter( (e,i) => e !== path);
+                        var candidatePaths = overlayPaths.filter( (i,e) => e !== path);
                         if (candidatePaths.length > 0) { // select another overlay of the component
                             var newPath = candidatePaths[0];
                             $(document).trigger('path:deleted', [path, newPath]);

--- a/console/src/main/resources/root/libs/composum/nodes/browser/js/nodeview.js
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/js/nodeview.js
@@ -960,6 +960,7 @@
                 this.favoriteToggle = this.$detailView.find('.favorite-toggle');
                 this.checkFavorite();
                 this.favoriteToggle.click(_.bind(this.toggleFavorite, this));
+                this.sourceViewTabVisibility();
             },
 
             checkFavorite: function () {

--- a/console/src/main/resources/root/libs/composum/nodes/browser/js/nodeview.js
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/js/nodeview.js
@@ -141,10 +141,10 @@
                 }
                 var extension = this.$extension.val();
                 if (extension) {
-                    if (extension == '-') {
+                    if (extension === '-') {
                         extension = '';
                     } else {
-                        if (extension.indexOf('.') != 0) {
+                        if (extension.indexOf('.') !== 0) {
                             extension = '.' + extension;
                         }
                     }
@@ -154,7 +154,7 @@
                 url += extension;
                 var suffix = this.$suffix.val();
                 if (suffix) {
-                    if (suffix.indexOf('/') != 0) {
+                    if (suffix.indexOf('/') !== 0) {
                         suffix = '/' + suffix;
                     }
                     url += suffix;
@@ -300,14 +300,13 @@
 
             initialize: function (options) {
                 browser.AbstractDisplayTab.prototype.initialize.apply(this, [options]);
-                this.$image = this.$('.image-frame img');
                 this.$('.detail-toolbar .update').click(_.bind(this.upload, this));
                 this.$download = this.$('.detail-toolbar .download');
             },
 
             reload: function () {
                 browser.AbstractDisplayTab.prototype.reload.apply(this);
-                this.$download.attr('href', core.getContextUrl('/bin/cpm/nodes/node.download.bin' + this.$el.data('path')));
+                this.$download.attr('href', core.getContextUrl('/bin/cpm/nodes/node.download.bin' + this.$el.data('file')));
             },
 
             upload: function () {
@@ -321,18 +320,35 @@
             }
         });
 
+        browser.BinaryTab = browser.AbstractFileTab.extend({
+
+            initialize: function (options) {
+                options = _.extend(options, {
+                    displayKey: 'binaryView',
+                    loadContent: _.bind(function (url) {
+                        core.getHtml('/bin/browser.tab.binary-view.html' + this.$el.data('file'),
+                            _.bind(function (content) {
+                                this.$container.html(content);
+                            }, this));
+                    }, this)
+                });
+                browser.AbstractFileTab.prototype.initialize.apply(this, [options]);
+                this.$container = this.$('.frame-container');
+            }
+        });
+
         browser.ImageTab = browser.AbstractFileTab.extend({
 
             initialize: function (options) {
                 this.isAsset = !!this.$el.data('asset');
                 options = _.extend(options, {
                     displayKey: 'imageView',
-                    loadContent: function (url) {
+                    loadContent: _.bind(function (url) {
                         if (!this.urlHasModifiers() && !this.isAsset) {
                             url = '/bin/cpm/nodes/node.load.bin' + url;
                         }
                         this.$image.attr('src', core.getContextUrl(url));
-                    }
+                    }, this)
                 });
                 browser.AbstractFileTab.prototype.initialize.apply(this, [options]);
                 this.$image = this.$('.image-frame img');
@@ -349,14 +365,14 @@
             initialize: function (options) {
                 options = _.extend(options, {
                     displayKey: 'videoView',
-                    loadContent: function (url) {
+                    loadContent: _.bind(function (url) {
                         if (!this.urlHasModifiers()) {
                             url = '/bin/cpm/nodes/node.load.bin' + url;
                         }
                         var mimeType = this.$el.data('type');
                         this.$source.attr('type', mimeType);
                         this.$source.attr('src', core.getContextUrl(url));
-                    }
+                    }, this)
                 });
                 browser.AbstractFileTab.prototype.initialize.apply(this, [options]);
                 this.$video = this.$('.video-frame video');
@@ -374,7 +390,7 @@
 
             reload: function () {
                 this.$download.attr('href', core.getContextUrl('/bin/cpm/nodes/node.download.bin'
-                    + this.$('.editor-frame .code-editor').data('path')));
+                    + this.$('.editor-frame .code-editor').data('file')));
             },
 
             resize: function () {
@@ -811,8 +827,8 @@
                 browser.nodeView.sourceViewTabVisibility('xml');
             },
 
-            getUrl: function (type) {
-                var type = type || "xml";
+            getUrl: function (typeOption) {
+                var type = typeOption || "xml";
                 var path = browser.getCurrentPath();
                 var url = '/bin/cpm/nodes/source.' + type + path;
                 return core.getContextUrl(url);
@@ -847,6 +863,9 @@
         }, {
             selector: '> .scene',
             tabType: browser.SceneTab
+        }, {
+            selector: '> .binary',
+            tabType: browser.BinaryTab
         }, {
             selector: '> .image',
             tabType: browser.ImageTab
@@ -911,13 +930,13 @@
             },
 
             onPathSelected: function (event, path) {
-                if (path == this.getCurrentPath()) {
+                if (path === this.getCurrentPath()) {
                     this.reload();
                 }
             },
 
             onPathChanged: function (event, path) {
-                if (path == this.getCurrentPath()) {
+                if (path === this.getCurrentPath()) {
                     this.reload();
                 }
             },

--- a/console/src/main/resources/root/libs/composum/nodes/browser/tabs/binary-view.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/tabs/binary-view.jsp
@@ -1,0 +1,14 @@
+<%@page session="false" pageEncoding="utf-8" %>
+<%@taglib prefix="sling" uri="http://sling.apache.org/taglibs/sling/1.2" %>
+<%@taglib prefix="cpn" uri="http://sling.composum.com/cpnl/1.0" %>
+<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<sling:defineObjects/>
+<cpn:component id="browser" type="com.composum.sling.nodes.browser.Browser" scope="request">
+    <c:if test="${browser.renderable}">
+        <iframe src="/bin/cpm/nodes/node.download.bin${cpn:path(browser.filePath)}" width="100%" height="100%"></iframe>
+    </c:if>
+    <c:if test="${!browser.renderable}">
+        <a href="/bin/cpm/nodes/node.download.bin${cpn:path(browser.filePath)}"
+           class="file-download"><span class="file-symbol fa fa-${browser.fileIcon}"></span></a>
+    </c:if>
+</cpn:component>

--- a/console/src/main/resources/root/libs/composum/nodes/browser/tabs/binary.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/tabs/binary.jsp
@@ -1,11 +1,23 @@
-<%@page session="false" pageEncoding="utf-8"%>
-<%@taglib prefix="sling" uri="http://sling.apache.org/taglibs/sling/1.2"%>
-<%@taglib prefix="cpn" uri="http://sling.composum.com/cpnl/1.0"%>
-<sling:defineObjects />
+<%@page session="false" pageEncoding="utf-8" %>
+<%@taglib prefix="sling" uri="http://sling.apache.org/taglibs/sling/1.2" %>
+<%@taglib prefix="cpn" uri="http://sling.composum.com/cpnl/1.0" %>
+<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<sling:defineObjects/>
 <cpn:component id="browser" type="com.composum.sling.nodes.browser.Browser" scope="request">
-  <div class="binary detail-panel">
-    <div class="frame-container detail-content">
-      <iframe src="${browser.current.pathEncoded}" width="100%" height="100%" sandbox=""></iframe>
+    <div class="binary detail-panel" data-file="${cpn:path(browser.filePath)}">
+        <div class="image-toolbar detail-toolbar">
+            <div class="btn-group btn-group-sm" role="group">
+                <button type="button" class="reload fa fa-refresh btn btn-default" title="Reload"><span class="label">Reload</span>
+                </button>
+            </div>
+            <div class="btn-group btn-group-sm" role="group">
+                <a href="" class="download fa fa-download btn btn-default" title="Download File"
+                   target="_blank"><span class="label">Download</span></a>
+                <button type="button" class="update fa fa-upload btn btn-default" title="Change Content"></button>
+            </div>
+        </div>
+        <div class="frame-container detail-content">
+            <sling:call script="tabs/binary-view.jsp"/>
+        </div>
     </div>
-  </div>
 </cpn:component>

--- a/console/src/main/resources/root/libs/composum/nodes/browser/tabs/editor.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/tabs/editor.jsp
@@ -28,7 +28,8 @@
                 </div>
             </div>
             <div class="editor-frame detail-content">
-                <div class="code-editor" data-path="${browser.contentResource.path}" data-type="${browser.textType}">
+                <div class="code-editor" data-path="${browser.contentResource.path}" data-file="${browser.filePath}"
+                     data-type="${browser.textType}">
                 </div>
             </div>
         </div>

--- a/console/src/main/resources/root/libs/composum/nodes/browser/tabs/image.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/tabs/image.jsp
@@ -4,6 +4,7 @@
 <sling:defineObjects/>
 <cpn:component id="browser" type="com.composum.sling.nodes.browser.Browser" scope="request">
     <div class="image detail-panel${browser.asset?' asset':''}" data-asset="${browser.asset}"
+         data-file="${cpn:path(browser.filePath)}"
          data-path="${browser.currentPathUrl}" data-mapped="${browser.currentUrl}">
         <div class="image-toolbar detail-toolbar">
             <div class="btn-group btn-group-sm" role="group">

--- a/console/src/main/resources/root/libs/composum/nodes/browser/tabs/video.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/tabs/video.jsp
@@ -3,8 +3,8 @@
 <%@taglib prefix="cpn" uri="http://sling.composum.com/cpnl/1.0" %>
 <sling:defineObjects/>
 <cpn:component id="browser" type="com.composum.sling.nodes.browser.Browser" scope="request">
-    <div class="video detail-panel" data-type="${browser.current.mimeType}" data-path="${browser.current.pathUrl}"
-         data-mapped="${browser.current.url}">
+    <div class="video detail-panel" data-type="${browser.current.mimeType}" data-file="${cpn:path(browser.filePath)}"
+         data-path="${cpn:path(browser.filePath)}" data-mapped="${browser.current.url}">
         <div class="video-toolbar detail-toolbar">
             <div class="btn-group btn-group-sm" role="group">
                 <span class="resolver fa fa-external-link btn btn-default" title="Resolver Mapping ON/OFF"></span>

--- a/console/src/main/resources/root/libs/composum/nodes/browser/views/binary.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/views/binary.jsp
@@ -9,9 +9,7 @@
     <div class="node-tabs detail-tabs action-bar btn-toolbar" role="toolbar">
       <div class="btn-group btn-group-sm" role="group">
         <a class="properties fa fa-list btn btn-default" href="#properties" data-group="properties" title="Node Properties"><span class="label">Properties</span></a>
-        <%--
-        <a class="download fa fa-download btn btn-default" href="#binary" data-group="binary" title="Download Binary Asset"><span class="label">Download</span></a>
-        --%>
+        <a class="download fa fa-${browser.fileIcon} btn btn-default" href="#binary" data-group="view" title="Download Binary Asset"><span class="label">Download</span></a>
         <a class="source json fa fa-code btn btn-default" href="#json" data-group="json" title="Source view as JSON (switchable to XML)"><span class="label">JSON</span></a>
         <a class="source xml fa fa-code btn btn-default hidden" href="#xml" data-group="xml" title="Source view as XML (switchable to JSON)"><span class="label">XML</span></a>
         <c:if test="${browser.canHaveAcl}">

--- a/console/src/main/resources/root/libs/composum/nodes/browser/views/binary.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/views/binary.jsp
@@ -14,8 +14,12 @@
         --%>
         <a class="source json fa fa-code btn btn-default" href="#json" data-group="json" title="Source view as JSON (switchable to XML)"><span class="label">JSON</span></a>
         <a class="source xml fa fa-code btn btn-default hidden" href="#xml" data-group="xml" title="Source view as XML (switchable to JSON)"><span class="label">XML</span></a>
-        <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
-        <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        <c:if test="${browser.canHaveAcl}">
+          <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
+        </c:if>
+        <c:if test="${browser.versionable}">
+          <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        </c:if>
       </div>
     </div>
     <div class="node-view-content detail-content">

--- a/console/src/main/resources/root/libs/composum/nodes/browser/views/component.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/views/component.jsp
@@ -19,10 +19,12 @@
                    title="Source view as JSON (switchable to XML)"><span class="label">JSON</span></a>
                 <a class="source xml fa fa-code btn btn-default hidden" href="#xml" data-group="xml"
                    title="Source view as XML (switchable to JSON)"><span class="label">XML</span></a>
-                <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span
-                        class="label">ACL</span></a>
-                <a class="version fa fa-history btn btn-default" href="#version" data-group="version"
-                   title="Versions"><span class="label">Versions</span></a>
+                <c:if test="${browser.canHaveAcl}">
+                    <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
+                </c:if>
+                <c:if test="${browser.versionable}">
+                    <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+                </c:if>
             </div>
         </div>
         <div class="node-view-content detail-content">

--- a/console/src/main/resources/root/libs/composum/nodes/browser/views/image.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/views/image.jsp
@@ -12,8 +12,12 @@
         <a class="view fa fa-eye btn btn-default" href="#image" data-group="view" title="Display Image"><span class="label">View</span></a>
         <a class="source json fa fa-code btn btn-default" href="#json" data-group="json" title="Source view as JSON (switchable to XML)"><span class="label">JSON</span></a>
         <a class="source xml fa fa-code btn btn-default hidden" href="#xml" data-group="xml" title="Source view as XML (switchable to JSON)"><span class="label">XML</span></a>
-        <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
-        <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        <c:if test="${browser.canHaveAcl}">
+          <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
+        </c:if>
+        <c:if test="${browser.versionable}">
+          <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        </c:if>
       </div>
     </div>
     <div class="node-view-content detail-content">

--- a/console/src/main/resources/root/libs/composum/nodes/browser/views/script.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/views/script.jsp
@@ -15,8 +15,12 @@
         <a class="code script fa fa-file-text-o btn btn-default" href="#script" data-group="edit" title="Script View/Run"><span class="label">Script</span></a>
         <a class="source json fa fa-code btn btn-default" href="#json" data-group="json" title="Source view as JSON (switchable to XML)"><span class="label">JSON</span></a>
         <a class="source xml fa fa-code btn btn-default hidden" href="#xml" data-group="xml" title="Source view as XML (switchable to JSON)"><span class="label">XML</span></a>
-        <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
-        <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        <c:if test="${browser.canHaveAcl}">
+          <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
+        </c:if>
+        <c:if test="${browser.versionable}">
+          <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        </c:if>
       </div>
     </div>
     <div class="node-view-content detail-content">

--- a/console/src/main/resources/root/libs/composum/nodes/browser/views/something.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/views/something.jsp
@@ -14,9 +14,11 @@
         </c:if>
         <a class="source json fa fa-code btn btn-default" href="#json" data-group="json" title="Source view as JSON (switchable to XML)"><span class="label">JSON</span></a>
         <a class="source xml fa fa-code btn btn-default hidden" href="#xml" data-group="xml" title="Source view as XML (switchable to JSON)"><span class="label">XML</span></a>
-        <c:if test="${browser.jcrResource}">
-        <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
-        <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        <c:if test="${browser.canHaveAcl}">
+          <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
+        </c:if>
+        <c:if test="${browser.versionable}">
+          <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
         </c:if>
       </div>
     </div>

--- a/console/src/main/resources/root/libs/composum/nodes/browser/views/something.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/views/something.jsp
@@ -14,8 +14,10 @@
         </c:if>
         <a class="source json fa fa-code btn btn-default" href="#json" data-group="json" title="Source view as JSON (switchable to XML)"><span class="label">JSON</span></a>
         <a class="source xml fa fa-code btn btn-default hidden" href="#xml" data-group="xml" title="Source view as XML (switchable to JSON)"><span class="label">XML</span></a>
+        <c:if test="${browser.jcrResource}">
         <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
         <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        </c:if>
       </div>
     </div>
     <div class="node-view-content detail-content">

--- a/console/src/main/resources/root/libs/composum/nodes/browser/views/text.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/views/text.jsp
@@ -12,7 +12,7 @@
         <c:if test="${browser.renderable}">
           <a class="view fa fa-eye btn btn-default" href="#display" data-group="view" title="Display Rendered View"><span class="label">View</span></a>
         </c:if>
-        <a class="code fa fa-file-text-o btn btn-default" href="#editor" data-group="edit" title="Text/Code View"><span class="label">Text/Code</span></a>
+        <a class="code fa fa-file-text-o btn btn-default" href="#editor" data-group="${browser.renderable?'edit':'view'}" title="Text/Code View"><span class="label">Text/Code</span></a>
         <a class="source json fa fa-code btn btn-default" href="#json" data-group="json" title="Source view as JSON (switchable to XML)"><span class="label">JSON</span></a>
         <a class="source xml fa fa-code btn btn-default hidden" href="#xml" data-group="xml" title="Source view as XML (switchable to JSON)"><span class="label">XML</span></a>
         <c:if test="${browser.canHaveAcl}">

--- a/console/src/main/resources/root/libs/composum/nodes/browser/views/text.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/views/text.jsp
@@ -15,8 +15,12 @@
         <a class="code fa fa-file-text-o btn btn-default" href="#editor" data-group="edit" title="Text/Code View"><span class="label">Text/Code</span></a>
         <a class="source json fa fa-code btn btn-default" href="#json" data-group="json" title="Source view as JSON (switchable to XML)"><span class="label">JSON</span></a>
         <a class="source xml fa fa-code btn btn-default hidden" href="#xml" data-group="xml" title="Source view as XML (switchable to JSON)"><span class="label">XML</span></a>
-        <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
-        <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        <c:if test="${browser.canHaveAcl}">
+          <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
+        </c:if>
+        <c:if test="${browser.versionable}">
+          <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        </c:if>
       </div>
     </div>
     <div class="node-view-content detail-content">

--- a/console/src/main/resources/root/libs/composum/nodes/browser/views/typed.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/views/typed.jsp
@@ -14,8 +14,12 @@
         </c:if>
         <a class="source json fa fa-code btn btn-default" href="#json" data-group="json" title="Source view as JSON (switchable to XML)"><span class="label">JSON</span></a>
         <a class="source xml fa fa-code btn btn-default hidden" href="#xml" data-group="xml" title="Source view as XML (switchable to JSON)"><span class="label">XML</span></a>
-        <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
-        <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        <c:if test="${browser.canHaveAcl}">
+          <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
+        </c:if>
+        <c:if test="${browser.versionable}">
+          <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        </c:if>
       </div>
     </div>
     <div class="node-view-content detail-content">

--- a/console/src/main/resources/root/libs/composum/nodes/browser/views/video.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/views/video.jsp
@@ -12,8 +12,12 @@
         <a class="view fa fa-eye btn btn-default" href="#video" data-group="view" title="Watch video"><span class="label">View</span></a>
         <a class="source json fa fa-code btn btn-default" href="#json" data-group="json" title="Source view as JSON (switchable to XML)"><span class="label">JSON</span></a>
         <a class="source xml fa fa-code btn btn-default hidden" href="#xml" data-group="xml" title="Source view as XML (switchable to JSON)"><span class="label">XML</span></a>
-        <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
-        <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        <c:if test="${browser.canHaveAcl}">
+          <a class="acl fa fa-key btn btn-default" href="#acl" data-group="acl" title="Access Rules"><span class="label">ACL</span></a>
+        </c:if>
+        <c:if test="${browser.versionable}">
+          <a class="version fa fa-history btn btn-default" href="#version" data-group="version" title="Versions"><span class="label">Versions</span></a>
+        </c:if>
       </div>
     </div>
     <div class="node-view-content detail-content">

--- a/console/src/main/resources/root/libs/composum/nodes/console/dialogs/file-update.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/console/dialogs/file-update.jsp
@@ -28,7 +28,7 @@
                     <div class="form-group binary">
                         <div class="checkbox">
                             <label><input name="adjustLastModified" class="smart" type="checkbox"
-                                          value="">${cpn:value(cpn:i18n(slingRequest,"adjust 'jcr:lastModified' properties"))}</label>
+                                          value="">${cpn:i18n(slingRequest,"adjust 'jcr:lastModified' properties")}</label>
                         </div>
                     </div>
                 </div>

--- a/console/src/main/resources/root/libs/composum/nodes/console/js/console.js
+++ b/console/src/main/resources/root/libs/composum/nodes/console/js/console.js
@@ -514,8 +514,13 @@
                             $tab = this.$detailView.find('a[data-group="' + group + '"]');
                         }
                         if (!$tab || $tab.length < 1) {
-                            // if the group of the last view is not available use the view of the first tab
-                            $tab = this.$detailTabs.find('a');
+                            if (group === 'edit') { // special fallback from 'edit' to 'view
+                                $tab = this.$detailView.find('a[data-group="view"]');
+                            }
+                            if (!$tab || $tab.length < 1) {
+                                // if the group of the last view is not available use the view of the first tab
+                                $tab = this.$detailTabs.find('a');
+                            }
                         }
                         // get the tab key from the links anchor and select the tab
                         var tab = $tab.attr('href').substring(1);


### PR DESCRIPTION
This PR contains various improvements for the browser:

1. Show ACL / versions view only for JCR resource nodes
2. binary view uncommented; some smaller view fixes
3. Fixes for the labels denoting the component's various overlays
4. observes sling:resourceSuperType also for content resources etc. (often used in AEM)
5. integrates web browser back / forward with the browser history
6. rework the overlay creation / deletion logic to work with missing overlays
7. select other overlay / base component if an overlay is deleted
8. bugfix: XML mode doesn't get reset to JSON after switching to other resources