### PR TITLE
Bugfix/281 content packages with no version are not gracefully handled

### DIFF
--- a/commons/src/main/resources/root/libs/composum/nodes/commons/components/js/core.js
+++ b/commons/src/main/resources/root/libs/composum/nodes/commons/components/js/core.js
@@ -313,11 +313,11 @@
         },
 
         isNotAuthorized: function (result) {
-            return result.status === 401 || result.status === 403;
+            return result && (result.status === 401 || result.status === 403);
         },
 
         isRestricted: function (result) {
-            return result.status === 405;
+            return result && result.status === 405;
         },
 
         getRestrictedMessage: function (callback) {

--- a/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/util/PackageUtil.java
+++ b/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/util/PackageUtil.java
@@ -216,7 +216,7 @@ public class PackageUtil {
                 if (pckgDef != null) {
                     filename.append(pckgDef.get(JcrPackageDefinition.PN_NAME));
                     String version = pckgDef.get(JcrPackageDefinition.PN_VERSION);
-                    if (version != null) {
+                    if (StringUtils.isNotBlank(version)) {
                         filename.append('-').append(version);
                     }
                     filename.append(".zip");
@@ -684,7 +684,7 @@ public class PackageUtil {
         writer.beginObject();
         writer.name(JcrPackageDefinition.PN_GROUP).value(definition.get(JcrPackageDefinition.PN_GROUP));
         writer.name(JcrPackageDefinition.PN_NAME).value(definition.get(JcrPackageDefinition.PN_NAME));
-        if (version != null) {
+        if (StringUtils.isNotBlank(version)) {
             writer.name(JcrPackageDefinition.PN_VERSION).value(version);
         }
         if (description != null) {

--- a/pckgmgr/src/main/resources/root/libs/composum/nodes/pckgmgr/dialogs/pckg-create.jsp
+++ b/pckgmgr/src/main/resources/root/libs/composum/nodes/pckgmgr/dialogs/pckg-create.jsp
@@ -34,7 +34,7 @@
                         <div class="form-group">
                             <label class="control-label">Version</label>
                             <input name="version" class="widget text-field-widget form-control" type="text"
-                                   placeholder="enter version key (number)" data-rules="mandatory"/>
+                                   placeholder="enter version key (number)"/>
                         </div>
                     </div>
 

--- a/pckgmgr/src/main/resources/root/libs/composum/nodes/pckgmgr/dialogs/pckg-delete.jsp
+++ b/pckgmgr/src/main/resources/root/libs/composum/nodes/pckgmgr/dialogs/pckg-delete.jsp
@@ -33,7 +33,7 @@
                         <div class="form-group">
                             <label class="control-label">Version</label>
                             <input name="version" class="widget text-field-widget form-control" type="text"
-                                   placeholder="enter version key (number)" data-rules="mandatory"/>
+                                   placeholder="enter version key (number)"/>
                         </div>
                     </div>
 

--- a/pckgmgr/src/main/resources/root/libs/composum/nodes/pckgmgr/jcrpckg/general/pckg-update.jsp
+++ b/pckgmgr/src/main/resources/root/libs/composum/nodes/pckgmgr/jcrpckg/general/pckg-update.jsp
@@ -34,7 +34,7 @@
                     <div class="form-group">
                         <label class="control-label">Version</label>
                         <input name="version" class="widget text-field-widget form-control" type="text"
-                               placeholder="enter version key (number)" data-rules="mandatory"/>
+                               placeholder="enter version key (number)"/>
                     </div>
                     <div class="form-group">
                         <label class="control-label">Description</label>


### PR DESCRIPTION
Makes the package version number optional ( #281 ) and fixes a minor bug leading to error messages in the console on some alerts.