### PR TITLE
Do not XSS filter the query before execution

### DIFF
--- a/commons/src/main/java/com/composum/sling/cpnl/CpnlElFunctions.java
+++ b/commons/src/main/java/com/composum/sling/cpnl/CpnlElFunctions.java
@@ -403,7 +403,15 @@ public class CpnlElFunctions {
      * @return the string with &lt;![CDATA[ ... ]]&gt; around
      */
     public static String cdata(String value) {
-        return value != null ? "<![CDATA[" + value + "]]>" : null;
+        String result = null;
+        if (value != null) {
+            if (value.contains("]]>")) {
+                result = "<![CDATA[" + value.replaceAll("]]>", "]]]]><![CDATA[>") + "]]>";
+            } else {
+                result = "<![CDATA[" + value + "]]>";
+            }
+        }
+        return result;
     }
 
     /**

--- a/commons/src/test/java/com/composum/sling/cpnl/CpnlElFunctionsTest.java
+++ b/commons/src/test/java/com/composum/sling/cpnl/CpnlElFunctionsTest.java
@@ -1,0 +1,17 @@
+package com.composum.sling.cpnl;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class CpnlElFunctionsTest {
+
+    @Test
+    public void cdata() {
+        assertEquals(null, CpnlElFunctions.cdata(null));
+        assertEquals("<![CDATA[<script>alert('hello');</script>]]>", CpnlElFunctions.cdata("<script>alert('hello');</script>"));
+        assertEquals("<![CDATA[abc]]>", CpnlElFunctions.cdata("abc"));
+        assertEquals("<![CDATA[abc]]]]><![CDATA[>xyz]]>", CpnlElFunctions.cdata("abc]]>xyz"));
+    }
+
+}

--- a/console/src/main/resources/root/libs/composum/nodes/browser/js/query.js
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/js/query.js
@@ -239,7 +239,7 @@
                     if (queries) {
                         content += '<ul class="template-links">';
                         for (var i = 0; i < queries.length; i++) {
-                            content += ('<li><a href="#" class="query-template">' + queries[i] + '</a></li>');
+                            content += ('<li><a href="#" class="query-template">' + _.escape(queries[i]) + '</a></li>');
                         }
                         content += '</ul>';
                     }

--- a/console/src/main/resources/root/libs/composum/nodes/browser/query/export/export.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/query/export/export.jsp
@@ -5,14 +5,14 @@
 <sling:defineObjects/>
 <cpn:component var="strategy" type="com.composum.sling.nodes.query.ExportCfg">
     <form class="query-export-form" method="POST"
-          action="/bin/cpm/nodes/node.query${strategy.selectors}.bin">
-        <input type="hidden" name="export" value="${strategy.exportType}"/>
-        <input type="hidden" name="query" value="${strategy.query}"/>
-        <input type="hidden" name="filter" value="${strategy.filter}"/>
-        <input type="hidden" name="separator" value="${strategy.separator}"/>
-        <input type="hidden" name="properties" value="${strategy.properties}"/>
-        <input type="hidden" name="filename" value="${strategy.filename}"/>
+          action="/bin/cpm/nodes/node.query${cpn:value(strategy.selectors)}.bin">
+        <input type="hidden" name="export" value="${cpn:value(strategy.exportType)}"/>
+        <input type="hidden" name="query" value="${cpn:value(strategy.query)}"/>
+        <input type="hidden" name="filter" value="${cpn:value(strategy.filter)}"/>
+        <input type="hidden" name="separator" value="${cpn:value(strategy.separator)}"/>
+        <input type="hidden" name="properties" value="${cpn:value(strategy.properties)}"/>
+        <input type="hidden" name="filename" value="${cpn:value(strategy.filename)}"/>
         <a class="query-export-link" href="#"
-           title="${cpn:i18n(slingRequest,strategy.description)}">${cpn:i18n(slingRequest,strategy.title)}</a>
+           title="${cpn:value(cpn:i18n(slingRequest,strategy.description))}">${cpn:text(cpn:i18n(slingRequest,strategy.title))}</a>
     </form>
 </cpn:component>


### PR DESCRIPTION
This removes the XSS.filter on the query before it is executed, as that can be harmful - #295 mentions that in some cases @ is encoded, which is deadly, and there are other scenarios for e.g. jcr:like where that filtering can destroy things. I checked again that the query is escaped on output, instead. (I did not XSS.filter it there, since it's escaped and destroying it in the output might be harmful, too.)