### PR TITLE
Add support for groovy 4.x

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -86,8 +86,8 @@
                         <Import-Package>
                             org.apache.sling.event.jobs.consumer.*;version="[1.1,3)",
                             org.apache.sling.event.jobs.*;version="[1.3,3)",
-                            groovy.*;version="[2.2,4]",
-                            org.codehaus.groovy.*;version="[2.2,4]",
+                            groovy.*;version="[2.2,5]",
+                            org.codehaus.groovy.*;version="[2.2,5]",
                             org.apache.sling.api.resource.*;version="[2.10,3)",
                             !sun.*,
                             !junit.*,

--- a/package/commons/pom.xml
+++ b/package/commons/pom.xml
@@ -85,8 +85,8 @@
                         <Import-Package>
                             org.apache.sling.event.jobs.consumer.*;version="[1.1,3)",
                             org.apache.sling.event.jobs.*;version="[1.3,3)",
-                            groovy.*;version="[2.2,4]",
-                            org.codehaus.groovy.*;version="[2.2,4]",
+                            groovy.*;version="[2.2,5]",
+                            org.codehaus.groovy.*;version="[2.2,5]",
                             org.apache.sling.api.resource.*;version="[2.10,3)",
                             !sun.*,
                             !junit.*,


### PR DESCRIPTION
Groovy 4.x has been available for a while and added a lot of new language features. I have created a new Sling instance with 4.x and everything is running perfectly (see screenshot)

<img width="789" alt="groovy-4" src="https://user-images.githubusercontent.com/4967758/218275170-7cbbec24-63ff-47ae-92e0-288de6c658dd.png">
