### PR TITLE
Release Creation Script

### DIFF
--- a/.github/settings-istrepo.xml
+++ b/.github/settings-istrepo.xml
@@ -20,6 +20,15 @@
             <username>${env.NEXUS_BUILD_USER}</username>
             <password>${env.NEXUS_BUILD_PASSWD}</password>
         </server>
+        <server>
+          <id>ossrh</id>
+            <username>${env.OSSRH_USER}</username>
+            <password>${env.OSSRH_PASSWD}</password>
+        </server>
+        <server>
+            <id>gpg.passphrase</id>
+            <passphrase>${env.GPG_PASSPHRASE}</passphrase>
+        </server>
     </servers>
 
     <mirrors>

--- a/.github/workflows/createerelease.yml
+++ b/.github/workflows/createerelease.yml
@@ -1,0 +1,165 @@
+# Creates a release and uploads that. We don't upload the site - that's done in the master.yml workflow once it's merged.
+# Since our build sometimes fails (because some tests occasionally fail for reasons not in our code) we make this robust:
+# the irreversible actions are done only after all builds are done. That is the git push and the release to maven central.
+# The copy to the Sonatype staging area is likely repeatable. That way you just have to restart the job if it fails,
+# with no harm done and no traces in git.
+
+name: Create Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  createrelease:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 3
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        # deliberately not: cache: maven
+
+    # TODO currently maven 3.9.0 creates an error in the maven-minify-plugin , so we use 3.8.7 as workaround
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: 3.8.7
+
+    - name: Dump event context for debugging
+      continue-on-error: true  # Debugging output only, and this annoyingly fails when the commit messge has a (
+      run: |
+        echo '${{ github.event_name }} for ${{ github.ref_type }} ${{ github.ref_name }} or ${{ github.event.ref }}'
+        # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push
+        echo 'github.event:'
+        echo '${{ toJSON(github.event) }}'
+
+    - name: Dump github context for debugging
+      continue-on-error: true  # Debugging output only, and this annoyingly fails when the commit message has a (
+      run: |
+          echo '${{ toJSON(github) }}'
+
+    - name: Git & Maven Status
+      run: |
+        mvn -version
+        git remote -v
+        git status --untracked-files --ignored
+        git log -3 --no-color --decorate
+
+    - name: Mvn Effective POM
+      run: mvn -B -ntp -s .github/settings-istrepo.xml -N help:effective-pom
+
+    - name: Mvn Effective Settings
+      run: mvn -B -ntp -s .github/settings-istrepo.xml -N help:effective-settings
+
+
+    - name: Import GPG key
+      env:
+        GPG_SECRET_KEYS: ${{ secrets.GPG_SECRET_KEYS }}
+        GPG_OWNERTRUST: ${{ secrets.GPG_OWNERTRUST }}
+      run: |
+        echo $GPG_SECRET_KEYS | base64 --decode | gpg --import --no-tty --batch --yes
+        echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust --no-tty --batch --yes
+        gpg --list-secret-keys --keyid-format LONG
+
+    - name: Configure git user for release commits
+      # specific to repository - we don't want that to be the same thing in a fork.
+      env:
+        X_RELEASE_USERNAME: ${{ vars.RELEASE_USERNAME  }}
+        X_RELEASE_USEREMAIL: ${{ vars.RELEASE_USEREMAIL  }}
+      run: |
+        git config --global user.email "${X_RELEASE_USERNAME}"
+        git config --global user.name "${X_RELEASE_USEREMAIL}"
+
+    - name: Git & Maven Status at the start
+      run: |
+        mvn -version
+        git remote -v
+        git status --untracked-files --ignored
+        git log -3 --no-color --decorate
+
+    - name: Mvn Effective POM
+      run: mvn -B -ntp -s .github/settings-istrepo.xml -N help:effective-pom
+
+    - name: Mvn Effective Settings
+      run: mvn -B -ntp -s .github/settings-istrepo.xml -N help:effective-settings
+
+    - name: Check that we are on snapshot branch before creating the release
+      run: |
+        mvn -version
+        echo "Version: "
+        mvn -s .github/settings-istrepo.xml help:evaluate -Dexpression=project.version -q -DforceStdout
+        mvn -s .github/settings-istrepo.xml help:evaluate -Dexpression=project.version -q -DforceStdout | egrep -- '-SNAPSHOT$' > /dev/null || exit 1
+        # unfortunately, this would require a snapshot parent if just called from the command line, so we cannot use it: :-(
+        # mvn org.apache.maven.plugins:maven-enforcer-plugin:3.2.1:enforce -Drules=requireSnapshotVersion
+
+    - name: Dry run
+      continue-on-error: true
+      run: |
+        mvn -version
+        mvn -B -ntp -s .github/settings-istrepo.xml -P nexus-staging clean release:clean
+        mvn -B -ntp -s .github/settings-istrepo.xml -P nexus-staging release:prepare -DdryRun=true -DpushChanges=false
+        mvn -B -ntp -s .github/settings-istrepo.xml -P nexus-staging release:perform -DdryRun=true -DlocalCheckout=true -DdeployAtEnd=true
+        mvn -B -ntp -s .github/settings-istrepo.xml -P nexus-staging clean release:clean
+        git clean -f -d -x
+
+    - name: Verify git is clean
+      run: |
+        git status --untracked-files --ignored
+        git log -3 --no-color --decorate
+        git clean -f -d
+
+    - name: Prepare release
+      run: |
+        git clean -f -d -x
+        mvn -B --no-transfer-progress -s .github/settings-istrepo.xml clean release:clean release:prepare -DpushChanges=false
+        cat release.properties || true
+
+    - name: Git status
+      run: |
+        git status --untracked-files --ignored
+        git log -3 --no-color --decorate
+        cat release.properties || true
+
+    - name: Perform release
+      env:
+        OSSRH_USER: ${{ secrets.OSSRH_USER  }}
+        OSSRH_PASSWD: ${{ secrets.OSSRH_PASSWD  }}
+        GPG_PASSPHRASE : ${{ secrets.GPG_PASSPHRASE }}
+      run: |
+        mvn -B --no-transfer-progress -s .github/settings-istrepo.xml -P nexus-staging release:perform -DlocalCheckout=true -DdeployAtEnd=true -Darguments="-Dgpg.passphrase=$GPG_PASSPHRASE" "-Dgpg.passphrase=$GPG_PASSPHRASE" "-Dgoals=clean install package source:jar javadoc:jar deploy"
+
+    - name: Git Status
+      if: always()
+      run: |
+        git status
+        git log -3 --no-color --decorate
+
+    - name: Git Status Long
+      if: always()
+      run: |
+        git status --untracked-files --ignored
+
+    - name: Push changes
+      run: |
+        echo FIXME UNIMPLEMENTED YET
+        echo git push would be done
+
+    - name: Release to maven central repository
+      run: |
+          echo FIXME UNIMPLEMENTED YET
+
+    - name: List target files even if recipe fails
+      if: always()
+      run: |
+        pwd
+        ls -ld
+        ls -ld target
+        find . -type d -name target
+        ls -l ./target/checkout/target || true
+        ls -l ./target/checkout/commons/target || true

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -37,10 +37,10 @@ jobs:
         mvn -version
 
     - name: Mvn Effective POM
-      run: mvn -B -ntp -s .github/settings-istrepo.xml help:effective-pom
+      run: mvn -B -ntp -s .github/settings-istrepo.xml -N help:effective-pom
 
     - name: Mvn Effective Settings
-      run: mvn -B -ntp -s .github/settings-istrepo.xml help:effective-settings
+      run: mvn -B -ntp -s .github/settings-istrepo.xml -N help:effective-settings
 
     - name: Build with Maven
       # When parent-2:1.7 is active, -P ensureSnapshots will do a sanity check of the version number

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,10 +37,10 @@ jobs:
         mvn -version
 
     - name: Mvn Effective POM
-      run: mvn -B -ntp -s .github/settings-istrepo.xml help:effective-pom
+      run: mvn -B -ntp -s .github/settings-istrepo.xml -N help:effective-pom
 
     - name: Mvn Effective Settings
-      run: mvn -B -ntp -s .github/settings-istrepo.xml help:effective-settings
+      run: mvn -B -ntp -s .github/settings-istrepo.xml -N help:effective-settings
 
     - name: Check versioning
       run: mvn -B -ntp -s .github/settings-public.xml org.apache.maven.plugins:maven-enforcer-plugin:3.0.0:enforce -Drules=requireReleaseVersion,requireReleaseDeps

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -36,10 +36,10 @@ jobs:
         mvn -version
 
     - name: Mvn Effective POM
-      run: mvn -B -ntp -s .github/settings-istrepo.xml help:effective-pom
+      run: mvn -B -ntp -s .github/settings-istrepo.xml -N help:effective-pom
 
     - name: Mvn Effective Settings
-      run: mvn -B -ntp -s .github/settings-istrepo.xml help:effective-settings
+      run: mvn -B -ntp -s .github/settings-istrepo.xml -N help:effective-settings
 
     - name: Testbuild with Maven
       run: mvn -B -ntp -s .github/settings-public.xml -P test -B verify

--- a/.github/workflows/setversion.yml
+++ b/.github/workflows/setversion.yml
@@ -50,10 +50,10 @@ jobs:
         mvn -version
 
     - name: Mvn Effective POM
-      run: mvn -B -ntp -s .github/settings-istrepo.xml help:effective-pom
+      run: mvn -B -ntp -s .github/settings-istrepo.xml -N help:effective-pom
 
     - name: Mvn Effective Settings
-      run: mvn -B -ntp -s .github/settings-istrepo.xml help:effective-settings
+      run: mvn -B -ntp -s .github/settings-istrepo.xml -N help:effective-settings
 
     - name: Set new version
       run: |

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,58 @@
                     <!-- FIXME use version from parent pom once changed; workaround for https://github.com/bndtools/bnd/issues/3903 -->
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>5.1.4</version>
+                    <version>5.1.8</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.5.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.5.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>3.4.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.12.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>3.0.1</version>
+                    <configuration>
+                        <keyname>info@composum.com</keyname>
+                        <passphraseServerId>info@composum.com</passphraseServerId>
+                        <gpgArguments>
+                            <arg>--batch</arg>
+                            <arg>--pinentry-mode</arg>
+                            <arg>loopback</arg>
+                            <arg>-v</arg>
+                        </gpgArguments>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -60,22 +60,12 @@
         <module>osgi</module>
         <module>setup</module>
         <module>package</module>
-        <module>test</module>
     </modules>
 
     <profiles>
         <profile>
             <id>test</id>
             <modules>
-                <module>jslibs</module>
-                <module>commons</module>
-                <module>console</module>
-                <module>pckgmgr</module>
-                <module>usermgr</module>
-                <module>corecfg</module>
-                <module>osgi</module>
-                <module>setup</module>
-                <module>package</module>
                 <module>xtracts/debugutil</module>
                 <!-- Test modules - no deployed code contained -->
                 <module>test</module>


### PR DESCRIPTION
This introduces a release creation script that creates a release and deploys that to Sonatype OSSRH. It's not yet fully active - it should upload the release to OSSRH staging, but not publish it and not push the changes to github.

To run the job see the internal documentation https://cloud.composum.com/content/ist/composum/home/internaldocumentatio/releasingWithGithub.html . There are also some configurations needed at the repository.