### PR TITLE
 closes #316 return all restrictions if there are multiple restrictions

### DIFF
--- a/console/src/main/java/com/composum/sling/nodes/servlet/SecurityServlet.java
+++ b/console/src/main/java/com/composum/sling/nodes/servlet/SecurityServlet.java
@@ -500,8 +500,10 @@ public class SecurityServlet extends AbstractServiceServlet {
             writer.name("restrictions").beginArray();
             for (String name : restrictionNames) {
                 try {
-                    Value value = entry.getRestriction(name);
-                    writer.value(name + "=" + (value != null ? value.toString() : "<null>"));
+                    Value[] restrictions = entry.getRestrictions(name);
+                    for (Value restriction : restrictions) {
+                        writer.value(name + "=" + (restriction != null ? restriction.toString() : "<null>"));
+                    }
                 } catch (Exception ex) {
                     writer.value(name + ":" + ex.toString());
                 }


### PR DESCRIPTION
Makes a sane display of the rep:subtrees restriction in the acl view, which can have multiple values at once. Thus fixes #316 sufficiently.
