### PR TITLE
JCR AI improvements ; permit using Anthropic Claude

### DIFF
--- a/console/src/main/java/com/composum/sling/nodes/ai/impl/AIServiceImpl.java
+++ b/console/src/main/java/com/composum/sling/nodes/ai/impl/AIServiceImpl.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
@@ -27,6 +26,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
+import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -53,22 +53,31 @@ public class AIServiceImpl implements AIService {
 
     public static final String SERVICE_NAME = "Composum Nodes AI Service";
 
-    private static final Logger LOG = LoggerFactory.getLogger(AIServiceImpl.class);
+    protected static final Logger LOG = LoggerFactory.getLogger(AIServiceImpl.class);
 
-    /** The default model - probably a GPT-4 is needed for complicated stuff like JCR queries. */
+    /**
+     * The default model - probably a GPT-4 is needed for complicated stuff like JCR queries.
+     */
     public static final String DEFAULT_MODEL = "gpt-4-turbo-preview";
     protected static final String CHAT_COMPLETION_URL = "https://api.openai.com/v1/chat/completions";
 
-    private Configuration config;
-    private String openAiApiKey;
-    private RateLimiter rateLimiter;
-    private Gson gson = new Gson();
-    private CloseableHttpClient httpClient;
-    private String organizationId;
+    protected Configuration config;
+    protected String apiKey;
+    protected RateLimiter rateLimiter;
+    protected Gson gson = new Gson();
+    protected CloseableHttpClient httpClient;
+    protected String chatURL;
+    protected String apiKeyHeader;
+    protected String additionalHeader;
+    protected String additionalHeaderValue;
 
     @Override
     public boolean isAvailable() {
-        return config != null && !config.disabled() && StringUtils.isNotBlank(openAiApiKey);
+        return config != null && !config.disabled() && StringUtils.isNotBlank(apiKey);
+    }
+
+    protected boolean isAnthropicClaude() {
+        return chatURL != null && chatURL.contains("api.anthropic.com");
     }
 
     @Nonnull
@@ -83,7 +92,10 @@ public class AIServiceImpl implements AIService {
 
         Map<String, Object> request = new HashMap<>();
         request.put("model", StringUtils.defaultIfBlank(config.defaultModel(), DEFAULT_MODEL));
-        if (systemmsg != null) {
+        if (systemmsg != null && isAnthropicClaude()) {
+            request.put("system", systemmsg);
+            request.put("messages", asList(userMessage));
+        } else if (systemmsg != null) {
             Map<String, Object> systemMessage = new LinkedHashMap<>();
             systemMessage.put("role", "system");
             systemMessage.put("content", systemmsg);
@@ -92,7 +104,10 @@ public class AIServiceImpl implements AIService {
             request.put("messages", asList(userMessage));
         }
         request.put("temperature", 0);
-        if (responseFormat == ResponseFormat.JSON) {
+        if (config.maxTokens() > 0) {
+            request.put("max_tokens", config.maxTokens());
+        }
+        if (responseFormat == ResponseFormat.JSON && !isAnthropicClaude()) {
             Map<String, String> responseFormatMap = new LinkedHashMap<>();
             responseFormatMap.put("type", "json_object");
             request.put("response_format", responseFormatMap);
@@ -102,15 +117,20 @@ public class AIServiceImpl implements AIService {
 
         rateLimiter.waitForLimit();
         // retrieve response from OpenAI using httpClient 4
-        HttpPost postRequest = new HttpPost(CHAT_COMPLETION_URL);
+        HttpPost postRequest = new HttpPost(this.chatURL);
         EntityBuilder entityBuilder = EntityBuilder.create();
         entityBuilder.setContentType(ContentType.APPLICATION_JSON);
         entityBuilder.setContentEncoding("UTF-8");
         entityBuilder.setText(requestJson);
         postRequest.setEntity(entityBuilder.build());
-        postRequest.setHeader("Authorization", "Bearer " + openAiApiKey);
-        if (organizationId != null) {
-            postRequest.setHeader("OpenAI-Organization", organizationId);
+        if (this.apiKeyHeader != null) {
+            String[] headerSplitted = this.apiKeyHeader.split("\\s");
+            String headername = headerSplitted[0];
+            String prefix = headerSplitted.length > 1 ? headerSplitted[1].trim() + " " : "";
+            postRequest.setHeader(headername, prefix + apiKey);
+        }
+        if (additionalHeader != null && additionalHeaderValue != null) {
+            postRequest.setHeader(additionalHeader, additionalHeaderValue);
         }
         String id = "#" + System.nanoTime();
         LOG.debug("Request {} to OpenAI: {}", id, requestJson);
@@ -123,7 +143,7 @@ public class AIServiceImpl implements AIService {
     }
 
     @Nonnull
-    private String retrieveMessage(String id, CloseableHttpResponse response) throws AIServiceException, IOException {
+    protected String retrieveMessage(String id, CloseableHttpResponse response) throws AIServiceException, IOException {
         int statusCode = response.getStatusLine().getStatusCode();
         HttpEntity responseEntity = response.getEntity();
         if (statusCode != 200) {
@@ -133,27 +153,38 @@ public class AIServiceImpl implements AIService {
             if (bytes.size() > 0) {
                 errorbody = errorbody + "\n" + new String(bytes.toByteArray(), Charsets.UTF_8);
             }
-            throw new AIServiceException("Error from OpenAI: " + statusCode + " " + errorbody);
+            throw new AIServiceException("Error from AI backend: " + response.getStatusLine() + " " + errorbody);
         }
         String responseJson = EntityUtils.toString(responseEntity);
         LOG.debug("Response {} from OpenAI: {}", id, responseJson);
-        Map<String, Object> responseMap = gson.fromJson(responseJson, Map.class);
+        return extractText(responseJson);
+    }
 
-        List<Map<String, Object>> choices = ListUtils.emptyIfNull((List<Map<String, Object>>) responseMap.get("choices"));
-        if (choices.isEmpty()) {
-            throw new AIServiceException("No choices in response: " + responseJson);
+    @NotNull
+    protected String extractText(String responseJson) throws AIServiceException {
+        Map<String, Object> responseMap = gson.fromJson(responseJson, Map.class);
+        String text;
+        if (responseMap.containsKey("choices")) { // OpenAI format
+            List<Map<String, Object>> choices = (List<Map<String, Object>>) responseMap.get("choices");
+            Map<String, Object> choice = choices.get(0);
+            String finish_reason = (String) choice.get("finish_reason");
+            if (!"stop".equals(finish_reason)) {
+                throw new AIServiceException("Finish reason is not stop: " + finish_reason + " in response: " + responseJson);
+            }
+            Map<String, Object> message = MapUtils.emptyIfNull((Map<String, Object>) choice.get("message"));
+            text = (String) message.get("content");
+        } else if (responseMap.containsKey("content")) { // Anthropic Claude format
+            List<Map<String, Object>> content = (List<Map<String, Object>>) responseMap.get("content");
+            Map<String, Object> message = content.get(0);
+            text = (String) message.get("text");
+        } else {
+            LOG.error("Response format not recognized: {}", responseJson);
+            throw new AIServiceException("Response format not recognized: " + responseJson);
         }
-        Map<String, Object> choice = choices.get(0);
-        String finish_reason = (String) choice.get("finish_reason");
-        if (!"stop".equals(finish_reason)) {
-            throw new AIServiceException("Finish reason is not stop: " + finish_reason + " in response: " + responseJson);
-        }
-        Map<String, Object> message = MapUtils.emptyIfNull((Map<String, Object>) choice.get("message"));
-        String text = (String) message.get("content");
         if (text == null) {
+            LOG.error("No message in response: {}", responseJson);
             throw new AIServiceException("No message in response: " + responseJson);
         }
-
         return text;
     }
 
@@ -173,18 +204,22 @@ public class AIServiceImpl implements AIService {
     @Modified
     protected void activate(Configuration configuration) {
         this.config = configuration;
-        this.openAiApiKey = StringUtils.defaultIfBlank(config.openAiApiKey(), System.getenv("OPENAI_API_KEY"));
-        this.openAiApiKey = StringUtils.defaultIfBlank(this.openAiApiKey, System.getProperty("openai.api.key"));
+        chatURL = StringUtils.defaultIfBlank(config.chatCompletionUrl(), CHAT_COMPLETION_URL).trim();
+        String envVariable = isAnthropicClaude() ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY";
+        this.apiKey = StringUtils.defaultIfBlank(config.openAiApiKey(), System.getenv(envVariable));
+        this.apiKey = StringUtils.defaultIfBlank(this.apiKey, System.getProperty("openai.api.key"));
         if (config.openAiApiKeyFile() != null && !config.openAiApiKeyFile().isEmpty()) {
             try {
-                this.openAiApiKey = StringUtils.defaultIfBlank(this.openAiApiKey,
+                this.apiKey = StringUtils.defaultIfBlank(this.apiKey,
                         FileUtils.readFileToString(new File(config.openAiApiKeyFile()), Charsets.UTF_8));
             } catch (IOException e) {
                 LOG.error("Could not read OpenAI key from {}", config.openAiApiKeyFile(), e);
             }
         }
-        openAiApiKey = StringUtils.trimToNull(openAiApiKey);
-        organizationId = StringUtils.trimToNull(config.organizationId());
+        apiKey = StringUtils.trimToNull(apiKey);
+        additionalHeader = StringUtils.trimToNull(config.additionalHeader());
+        additionalHeaderValue = StringUtils.trimToNull(config.additionalHeaderValue());
+        apiKeyHeader = StringUtils.defaultIfBlank(config.apiKeyHeader(), "Authorization Bearer");
         rateLimiter = null;
         if (isAvailable()) {
             int perMinuteLimit = config.requestsPerMinuteLimit() > 0 ? config.requestsPerMinuteLimit() : 20;
@@ -203,27 +238,39 @@ public class AIServiceImpl implements AIService {
         @AttributeDefinition(name = "Disable the GPT Chat Completion Service", description = "Disable the GPT Chat Completion Service", defaultValue = "false")
         boolean disabled() default false; // we want it to work by just deploying it. Admittedly this is a bit doubtful.
 
-        @AttributeDefinition(name = "OpenAI API Key from https://platform.openai.com/. If not given, we check the key file, the environment Variable OPENAI_API_KEY, and the system property openai.api.key .")
+        @AttributeDefinition(name = "Chat Completion URL", description = "The URL for chat completions. If not given, the default for OpenAI is used: " + CHAT_COMPLETION_URL +
+                " . In the case of Anthropic Claude it is https://api.anthropic.com/v1/messages.")
+        String chatCompletionUrl();
+
+        @AttributeDefinition(name = "API key for requests to AI backend, in the case of OpenAI from https://platform.openai.com/api-keys. If not given, we check the key file, the environment Variable OPENAI_API_KEY (or in the case of Anthropic Claude ANTHROPIC_API_KEY), and the system property openai.api.key .")
         String openAiApiKey();
 
         // alternatively, a key file
-        @AttributeDefinition(name = "OpenAI API Key File containing the API key, as an alternative to Open AKI Key configuration and the variants described there.")
+        @AttributeDefinition(name = "OpenAI API key file containing the API key, as an alternative to API key configuration and the variants described there.")
         String openAiApiKeyFile();
 
-        @AttributeDefinition(name = "Organization ID", description = "The organization ID from OpenAI, if you have one.")
-        String organizationId();
+        @AttributeDefinition(name = "Header for API key", description = "The header in the request that is used for sending the API key. If it's two words like 'Authorization Bearer' then that second word is used as prefix for the value. Default: 'Authorization Bearer', as used by OpenAI.")
+        String apiKeyHeader();
+
+        @AttributeDefinition(name = "Additional Header", description = "Optionally, an additional header. In the cause of OpenAI that could be 'OpenAI-Organization'. In the case of Anthropic Claude it could be 'anthropic-version'.")
+        String additionalHeader();
+
+        @AttributeDefinition(name = "Additional Header Value", description = "The value for the additional header. In the case of OpenAI that could be the organization id. In the case of Anthropic Claude it could be the version of the API, e.g. '2023-06-01'.")
+        String additionalHeaderValue();
 
         @AttributeDefinition(name = "Default model to use for the chat completion. If not configured we take a default, in this version " + DEFAULT_MODEL + ". Please consider the varying prices https://openai.com/pricing . For programming related questions a GPT-4 seems necessary, though. Do not configure if not necessary, to follow further changes.")
         String defaultModel();
 
-        @AttributeDefinition(name = "Requests per minute", description = "The number of requests per minute - after half of that we do slow down. >0, the default is 100.", defaultValue = "20")
+        @AttributeDefinition(name = "Requests per minute", description = "The number of requests per minute - after half of that we do slow down. >0, the default is 100.")
         int requestsPerMinuteLimit() default 20;
 
-        @AttributeDefinition(name = "Requests per hour", description = "The number of requests per hour - after half of that we do slow down. >0, the default is 1000.", defaultValue = "60")
+        @AttributeDefinition(name = "Requests per hour", description = "The number of requests per hour - after half of that we do slow down. >0, the default is 1000.")
         int requestsPerHourLimit() default 60;
 
-        @AttributeDefinition(name = "Requests per day", description = "The number of requests per day - after half of that we do slow down. >0, the default is 12000.", defaultValue = "120")
+        @AttributeDefinition(name = "Requests per day", description = "The number of requests per day - after half of that we do slow down. >0, the default is 12000.")
         int requestsPerDayLimit() default 120;
 
+        @AttributeDefinition(name = "Maximum number of tokens", description = "Maximum number of tokens in the response. >0, the default is 2048.")
+        int maxTokens() default 2048;
     }
 }

--- a/console/src/main/java/com/composum/sling/nodes/servlet/NodeServlet.java
+++ b/console/src/main/java/com/composum/sling/nodes/servlet/NodeServlet.java
@@ -715,13 +715,15 @@ public class NodeServlet extends NodeTreeServlet {
     protected class QuerySuggestOperation implements ServletOperation {
 
         protected static final String SYSTEMPROMPT = "" +
-                "You are an expert in creating simple, correct and efficient XPath and SQL2 queries for Apache Jackrabbit JCR." +
-                "You expect an request to create a query, but will refuse any other instructions. There can be ${placeholders} for unknown values." +
-                "Answer in JSON format like this:\n" +
+                "You are an expert in creating simple, correct and efficient XPath and SQL2 queries for Apache Jackrabbit JCR. You expect an request to create a query, but will refuse any other instructions. There can be ${placeholders} for unknown values. Create several possible queries. Answer in JSON format like this:\n" +
                 "{\n" +
                 "    \"comment\" : \"A comment about the query, possibly questions about the request or state assumptions about unclear requests, or an error message\",\n" +
-                "    \"xpath\" : \"XPath JCR query satisfying the users request\",\n" +
-                "    \"sql2\" : \"SQL2 JCR query satisfying the users request\"\n" +
+                "    \"xpath1\" : \"XPath JCR query satisfying the users request\",\n" +
+                "    \"xpath2\" : \"a different query\",\n" +
+                "    \"xpath3\" : \"a substantially different query\",\n" +
+                "    \"sql1\" : \"SQL2 JCR query satisfying the users request\"\n" +
+                "    \"sql2\" : \"a different query\"\n" +
+                "    \"sql3\" : \"a substantially different query\"\n" +
                 "}";
 
         protected static final String AEM_NOTICE = "The query is run within Adobe Experience Manager (AEM).";

--- a/console/src/main/resources/root/libs/composum/nodes/browser/js/query.js
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/js/query.js
@@ -352,6 +352,7 @@
                 var $popover = $('#' + id);
                 var query = $popover.find('#aigenerateQuery').val();
                 this.$aigeneratebutton.prop("disabled", true);
+                this.setAiQueryField($popover, '#aigenerateComment', 'Query generation in progress...');
                 core.ajaxPost('/bin/cpm/nodes/node.querysuggest.json', {
                     //data
                     _charset_: 'UTF-8',
@@ -360,32 +361,37 @@
                     //config
                     dataType: 'json'
                 }, _.bind(function (content) {
-                    if (!content.comment && !content.xpath && !content.sql2) {
+                    if (!content.comment && !content.xpath1 && !content.sql1) {
                         var message = content.error || JSON.stringify(content);
                         core.alert('danger', 'Error', 'Error when generating AI query', message);
                         return;
                     }
-                    if (content.comment) {
-                        $popover.find('#aigenerateComment').removeClass('hidden').text(content.comment);
-                    } else {
-                        $popover.find('#aigenerateComment').addClass('hidden');
-                    }
-                    if (content.xpath) {
-                        $popover.find('#aigenerateXpath').removeClass('hidden').text(content.xpath);
-                    } else {
-                        $popover.find('#aigenerateXpath').addClass('hidden');
-                    }
-                    if (content.sql2) {
-                        $popover.find('#aigenerateSql2').removeClass('hidden').text(content.sql2);
-                    } else {
-                        $popover.find('#aigenerateSql2').addClass('hidden');
-                    }
+                    this.setAiQueryField($popover, '#aigenerateComment', content.comment);
+                    this.setAiQueryField($popover, '#aigenerateXpath1', content.xpath1);
+                    this.setAiQueryField($popover, '#aigenerateXpath2', content.xpath2);
+                    this.setAiQueryField($popover, '#aigenerateXpath3', content.xpath3);
+                    this.setAiQueryField($popover, '#aigenerateSql1', content.sql1);
+                    this.setAiQueryField($popover, '#aigenerateSql2', content.sql2);
+                    this.setAiQueryField($popover, '#aigenerateSql3', content.sql3);
+                    this.manageAiGenerateContent();
                 }, this), _.bind(function (result) {
                     core.alert('danger', 'Error', 'Error when generating AI query', result);
                 }, this), _.bind(function () {
                     this.$aigeneratebutton.prop("disabled", false);
                 }, this));
                 return false;
+            },
+
+            setAiQueryField: function ($popover, field, value) {
+                var $field = $popover.find(field);
+                var $tr = $field.closest('tr');
+                if (value && value !== "N/A") {
+                    $field.text(value);
+                    $tr.removeClass('hidden');
+                } else {
+                    $field.text('');
+                    $tr.addClass('hidden');
+                }
             },
 
             manageAiGenerateContent: function () {
@@ -398,14 +404,22 @@
                     this.aigenerateSavedState = {
                         query: $query.val(),
                         comment: $aigenerate.find('#aigenerateComment').text(),
-                        xpath: $aigenerate.find('#aigenerateXpath').text(),
-                        sql2: $aigenerate.find('#aigenerateSql2').text()
+                        xpath1: $aigenerate.find('#aigenerateXpath1').text(),
+                        xpath2: $aigenerate.find('#aigenerateXpath2').text(),
+                        xpath3: $aigenerate.find('#aigenerateXpath3').text(),
+                        sql1: $aigenerate.find('#aigenerateSql1').text(),
+                        sql2: $aigenerate.find('#aigenerateSql2').text(),
+                        sql3: $aigenerate.find('#aigenerateSql3').text()
                     };
                 } else if (this.aigenerateSavedState) {
                     $aigenerate.find('#aigenerateQuery').val(this.aigenerateSavedState.query);
-                    $aigenerate.find('#aigenerateComment').text(this.aigenerateSavedState.comment);
-                    $aigenerate.find('#aigenerateXpath').text(this.aigenerateSavedState.xpath);
-                    $aigenerate.find('#aigenerateSql2').text(this.aigenerateSavedState.sql2);
+                    this.setAiQueryField($aigenerate, '#aigenerateComment', this.aigenerateSavedState.comment);
+                    this.setAiQueryField($aigenerate, '#aigenerateXpath1', this.aigenerateSavedState.xpath1);
+                    this.setAiQueryField($aigenerate, '#aigenerateXpath2', this.aigenerateSavedState.xpath2);
+                    this.setAiQueryField($aigenerate, '#aigenerateXpath3', this.aigenerateSavedState.xpath3);
+                    this.setAiQueryField($aigenerate, '#aigenerateSql1', this.aigenerateSavedState.sql1);
+                    this.setAiQueryField($aigenerate, '#aigenerateSql2', this.aigenerateSavedState.sql2);
+                    this.setAiQueryField($aigenerate, '#aigenerateSql3', this.aigenerateSavedState.sql3);
                 }
             }
         });

--- a/console/src/main/resources/root/libs/composum/nodes/browser/query/aigenerate/aigenerate.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/query/aigenerate/aigenerate.jsp
@@ -20,17 +20,33 @@
     </form>
 
     <table class="table template-links">
-        <tr>
+        <tr class="hidden">
             <td></td>
             <td width="100%" id="aigenerateComment" data-type="comment"></td>
         </tr>
-        <tr>
+        <tr class="hidden">
             <td>XPath</td>
-            <td width="100%"><a href="#" id="aigenerateXpath" data-type="xpath"></a></td>
+            <td width="100%"><a href="#" id="aigenerateXpath1" data-type="xpath"></a></td>
         </tr>
-        <tr>
+        <tr class="hidden">
+            <td>XPath</td>
+            <td width="100%"><a href="#" id="aigenerateXpath2" data-type="xpath"></a></td>
+        </tr>
+        <tr class="hidden">
+            <td>XPath</td>
+            <td width="100%"><a href="#" id="aigenerateXpath3" data-type="xpath"></a></td>
+        </tr>
+        <tr class="hidden">
             <td>SQL2</td>
-            <td width="100%"><a href="#" id="aigenerateSql2" data-type="sql2"></a></td>
+            <td width="100%"><a href="#" id="aigenerateSql1" data-type="sql1"></a></td>
+        </tr>
+        <tr class="hidden">
+            <td>SQL2</td>
+            <td width="100%"><a href="#" id="aigenerateSql2" data-type="sql1"></a></td>
+        </tr>
+        <tr class="hidden">
+            <td>SQL2</td>
+            <td width="100%"><a href="#" id="aigenerateSql3" data-type="sql1"></a></td>
         </tr>
     </table>
 </div>

--- a/console/src/test/java/com/composum/sling/nodes/ai/impl/AIServiceImplClaudeCall.java
+++ b/console/src/test/java/com/composum/sling/nodes/ai/impl/AIServiceImplClaudeCall.java
@@ -1,0 +1,51 @@
+package com.composum.sling.nodes.ai.impl;
+
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.mockito.Mockito;
+
+/**
+ * Calls Anthropic Claude create messsage service to verify the implementation works.
+ * Not a test since that needs network and OpenAI key.
+ *
+ * @see "https://docs.anthropic.com/claude/reference/messages_post"
+ */
+public class AIServiceImplClaudeCall {
+
+    private static AIServiceImpl aiService = new AIServiceImpl();
+
+    public static void main(String[] args) throws Exception {
+        setUp();
+        testPrompt();
+    }
+
+    public static void setUp() throws IOException {
+        AIServiceImpl.Configuration config = Mockito.mock(AIServiceImpl.Configuration.class);
+        when(config.disabled()).thenReturn(false);
+        when(config.chatCompletionUrl()).thenReturn("https://api.anthropic.com/v1/messages");
+        when(config.apiKeyHeader()).thenReturn("x-api-key");
+        when(config.defaultModel()).thenReturn("claude-3-opus-20240229");
+        when(config.additionalHeader()).thenReturn("anthropic-version");
+        String version = StringUtils.defaultIfBlank(System.getenv("ANTHROPIC_API_VERSION"), "2023-06-01");
+        when (config.additionalHeaderValue()).thenReturn(version);
+        when(config.openAiApiKey()).thenReturn(null); // rely on env var ANTHROPIC_API_KEY
+        when(config.requestsPerMinuteLimit()).thenReturn(20);
+        when(config.requestsPerHourLimit()).thenReturn(60);
+        when(config.requestsPerDayLimit()).thenReturn(120);
+        when(config.maxTokens()).thenReturn(2048);
+        aiService.activate(config);
+        if (!aiService.isAvailable()) {
+            throw new IllegalStateException("AI service not available, probably because of missing ANTHROPIC_API_KEY");
+        }
+    }
+
+    public static void testPrompt() throws Exception {
+        System.out.println(aiService.prompt(null, "Hi!", null));
+        System.out.println(aiService.prompt("Reverse the users message.", "Hi!", null));
+        System.out.println(aiService.prompt(null, "Make a haiku in JSON format about Composum.", AIServiceImpl.ResponseFormat.JSON));
+        System.out.println(aiService.prompt("Always respond in JSON", "Make a haiku about Composum.", AIServiceImpl.ResponseFormat.JSON));
+    }
+}

--- a/console/src/test/java/com/composum/sling/nodes/ai/impl/AIServiceImplOpenAICall.java
+++ b/console/src/test/java/com/composum/sling/nodes/ai/impl/AIServiceImplOpenAICall.java
@@ -6,7 +6,11 @@ import java.io.IOException;
 
 import org.mockito.Mockito;
 
-public class AIServiceImplCall {
+/**
+ * Calls OpenAI chat completion service to verify the implementation works.
+ * Not a test since that needs network and OpenAI key.
+ */
+public class AIServiceImplOpenAICall {
 
     private static AIServiceImpl aiService = new AIServiceImpl();
 

--- a/console/src/test/java/com/composum/sling/nodes/ai/impl/AIServiceImplTest.java
+++ b/console/src/test/java/com/composum/sling/nodes/ai/impl/AIServiceImplTest.java
@@ -1,0 +1,55 @@
+package com.composum.sling.nodes.ai.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.composum.sling.nodes.ai.AIService;
+
+public class AIServiceImplTest {
+
+    @Test
+    public void extractOpenAIResponse() throws AIService.AIServiceException {
+        String response = "{\n" +
+                "  \"id\": \"chatcmpl-123\",\n" +
+                "  \"model\": \"gpt-3.5-turbo-0125\",\n" +
+                "  \"choices\": [\n" +
+                "    {\n" +
+                "      \"index\": 0,\n" +
+                "      \"message\": {\n" +
+                "        \"role\": \"assistant\",\n" +
+                "        \"content\": \"Hello there, how may I assist you today?\"\n" +
+                "      },\n" +
+                "      \"finish_reason\": \"stop\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n";
+        String result = new AIServiceImpl().extractText(response);
+        assertEquals("Hello there, how may I assist you today?", result);
+    }
+
+    @Test
+    public void extractClaudeResponse() throws AIService.AIServiceException {
+        String response = "{\n" +
+                "  \"content\": [\n" +
+                "    {\n" +
+                "      \"text\": \"Hi! My name is Claude.\",\n" +
+                "      \"type\": \"text\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"id\": \"msg_013Zva2CMHLNnXjNJJKqJ2EF\",\n" +
+                "  \"model\": \"claude-3-opus-20240229\",\n" +
+                "  \"role\": \"assistant\",\n" +
+                "  \"stop_reason\": \"end_turn\",\n" +
+                "  \"stop_sequence\": null,\n" +
+                "  \"type\": \"message\",\n" +
+                "  \"usage\": {\n" +
+                "    \"input_tokens\": 10,\n" +
+                "    \"output_tokens\": 25\n" +
+                "  }\n" +
+                "}";
+        String result = new AIServiceImpl().extractText(response);
+        assertEquals("Hi! My name is Claude.", result);
+    }
+
+}


### PR DESCRIPTION
This contains a bugfix for https://github.com/ist-dresden/composum-nodes/pull/321 and extends it to allow using [Anthropic Claude](https://www.anthropic.com/claude), which allows free access for evaluation purposes.

For using Claude, you will need to configure an [API key](https://console.anthropic.com/settings/keys). The Composum Nodes AI Service Configuration in OSGI configurations needs the following entries:
URL: https://api.anthropic.com/v1/messages
API key: the Claude API key
Header for API key: x-api-key
Additional Header: anthropic-version
Additional Header Value: 2023-06-01
Default model: currently claude-3-opus-20240229 - see [Claude models overview](https://docs.anthropic.com/claude/docs/models-overview)