### PR TITLE
Bugfix/caconfigfixes

### DIFF
--- a/console/src/main/java/com/composum/sling/nodes/components/CAConfigModel.java
+++ b/console/src/main/java/com/composum/sling/nodes/components/CAConfigModel.java
@@ -126,6 +126,12 @@ public class CAConfigModel extends ConsoleServletBean {
 
     public List<ContextResource> getContextPaths() {
         List<ContextResource> contextResources = IteratorUtils.toList(contextPathStrategyMultiplexer.findContextResources(getResource()));
+        contextResources = contextResources.stream()
+                .filter(contextResource ->
+                        getResolver().getResource(contextResource.getConfigRef()) != null)
+                .filter(contextResource ->
+                        getResolver().getResource(contextResource.getConfigRef() + "/sling:configs") != null)
+                .collect(Collectors.toList());
         return contextResources;
     }
 

--- a/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
+++ b/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
@@ -343,6 +343,7 @@ public class SourceModel extends ConsoleSlingBean {
         addNameNamespace(keys, resource.getName());
         boolean subnodeInFullCoverage = inFullCoverage || isFullCoverageNode();
         for (Resource subnode : getSubnodeList()) {
+            addNameNamespace(keys, subnode.getName());
             SourceModel subnodeModel = new SourceModel(config, context, subnode);
             if (subnodeModel.getRenderingType(subnodeModel.getResource(), subnodeInFullCoverage) == RenderingType.EMBEDDED) {
                 subnodeModel.determineNamespaces(keys, subnodeInFullCoverage);

--- a/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
+++ b/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
@@ -171,6 +171,9 @@ public class SourceModel extends ConsoleSlingBean {
     protected transient Boolean[] hasOrderableChildren;
     protected transient Comparator<Property> propertyComparator;
 
+    /** Some things look like namespaces but aren't actual namespaces. This saves them. */
+    protected transient List<String> nonExistingNamespaces = new ArrayList<>();
+
     public SourceModel(NodesConfiguration config, BeanContext context, Resource resource) {
         this.config = config;
         initialize(context, resource);
@@ -213,7 +216,7 @@ public class SourceModel extends ConsoleSlingBean {
     }
 
     /**
-     * @param path a resource path in the resource repository tree; maybe a mounted resource path
+     * @param aPath a resource path in the resource repository tree; maybe a mounted resource path
      * @return 'true' if the path is equal to the export root path
      */
     public boolean isRootPath(@NotNull final String aPath) {
@@ -907,13 +910,23 @@ public class SourceModel extends ConsoleSlingBean {
                     }
                 } catch (NamespaceException nsex) {
                     LOG.debug(nsex.toString());
+                    nonExistingNamespaces.add(ns);
                 }
             }
         }
     }
 
     public String escapeXmlName(String propertyName) {
-        return ISO9075.encode(propertyName);
+        String encoded = ISO9075.encode(propertyName);
+        // If the attribute has a colon which does not start a namespace, we still need to encode that.
+        if (encoded.contains(":")) {
+            int pos = encoded.indexOf(':');
+            String prefix = encoded.substring(0, pos);
+            if (nonExistingNamespaces.contains(prefix)) {
+                encoded = encoded.replaceAll(":", "_x003A_");
+            }
+        }
+        return encoded;
     }
 
     /**

--- a/console/src/main/resources/root/libs/composum/nodes/browser/components/caconfig/effectiveConfigurationsView/content.jsp
+++ b/console/src/main/resources/root/libs/composum/nodes/browser/components/caconfig/effectiveConfigurationsView/content.jsp
@@ -20,7 +20,7 @@
 
     <p>
         To edit the configuration go to the mentioned configuration locations.
-        For creating new configurations - the following nodes are currently connected via sling:configRef:
+        For creating new configurations - the following nodes are currently connected:
     </p>
     <ul>
         <c:forEach var="contextResource" items="${model.contextPaths}">
@@ -29,7 +29,7 @@
                    data-path="${contextResource.configRef}/sling:configs">${contextResource.configRef}/sling:configs</a>
                 referenced by
                 <a class="target-link"
-                   data-path="${contextResource.resource.path}/sling:configs">${contextResource.resource.path}/sling:configs</a>
+                   data-path="${contextResource.resource.path}">${contextResource.resource.path}</a>
                 (ranking ${contextResource.serviceRanking})
             </li>
         </c:forEach>
@@ -119,7 +119,7 @@
 
     <c:forEach var="collection"
                items="${model.collectionConfigurations}">
-        <c:if test="${not empty collection.collectionConfigData.resourcePath}">
+        <c:if test="${not empty collection.collectionConfigData.resourcePath and not empty collection.collectionConfigData.items}">
             <%--@elvariable id="collection" type="com.composum.sling.nodes.components.CAConfigModel.CollectionConfigInfo"--%>
             <div class="panel panel-default">
                 <div class="panel-heading">

--- a/test/src/test/java/com/composum/sling/nodes/servlet/SourceModelTest.java
+++ b/test/src/test/java/com/composum/sling/nodes/servlet/SourceModelTest.java
@@ -188,7 +188,7 @@ public class SourceModelTest {
         String zipContents = getZipContentOverview(out, true, true);
         System.out.println(zipContents);
         assertThat(zipContents, is(".content.xml : 292 | 504953282\n" +
-                "assetsfolder/.content.xml : 200 | 2815730915\n" +
+                "assetsfolder/.content.xml : 249 | 213389511\n" +
                 "assetsfolder/_nt_resourcewithoutfile : 83358 | 2844564088\n" +
                 "assetsfolder/_nt_resourcewithoutfile.dir/.content.xml : 221 | 1068843391\n" +
                 "assetsfolder/plain.jpg : 76910 | 2714537933\n" +


### PR DESCRIPTION
Some fixes for CA configuration display and some fixes on SourceModel for node names like cq:tags and attribute names with a colon that are not namespaced.